### PR TITLE
[Feature] 카테고리, 게시물 테이블 연관 데이터 동시에 조회 기능 추가

### DIFF
--- a/controllers/post.controller.js
+++ b/controllers/post.controller.js
@@ -94,25 +94,34 @@ exports.findAll = (req, res) => {
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
-        Post.findAll({ order: [["postID", asc]] })
+        Post.findAll({
+            order: [["postID", asc]],
+            include: [
+                {
+                    model: Photo,
+                    as: "photos",
+                    attributes: ["photoID", "url"],
+                },
+            ],
+        })
             .then((data) => {
                 res.send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${postLabel} 테이블`
+                        `${postLabel} + ${photoLabel} 테이블`
                     )}의 모든 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                 );
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${postLabel} 테이블을 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${postLabel} + ${photoLabel} 테이블을 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${postLabel} 테이블`
+                        `${postLabel} + ${photoLabel} 테이블`
                     )}을 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
                         `상세정보: ${err.message}`
                     )} (IP: ${IP})`

--- a/controllers/post.controller.js
+++ b/controllers/post.controller.js
@@ -144,44 +144,36 @@ exports.findOne = (req, res) => {
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
-        Post.findByPk(id)
+        Post.findAll({
+            where: { postID: id },
+            include: [
+                {
+                    model: Photo,
+                    as: "photos",
+                    attributes: ["photoID", "url"],
+                },
+            ],
+        })
             .then((data) => {
-                if (data) {
-                    res.send(data);
-                    console.log(
-                        `[${moment().format(
-                            dateFormat
-                        )}] ${success} ${chalk.yellow(
-                            `${postLabel} 테이블`
-                        )}의 ${chalk.yellow(
-                            `${id}번`
-                        )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
-                    );
-                } else {
-                    res.status(400).send({
-                        message: `${postLabel} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
-                    });
-                    console.log(
-                        `[${moment().format(
-                            dateFormat
-                        )}] ${badAccessError} ${chalk.yellow(
-                            `${postLabel} 테이블`
-                        )}에서 ${chalk.yellow(
-                            `${id}번`
-                        )} 데이터를 찾을 수 없습니다. (IP: ${IP})`
-                    );
-                }
+                res.send(data);
+                console.log(
+                    `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
+                        `${postLabel} + ${photoLabel} 테이블`
+                    )}의 ${chalk.yellow(
+                        `${id}번`
+                    )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                );
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${postLabel} 테이블의 ${id}번 데이터를 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${postLabel} + ${photoLabel} 테이블의 ${id}번 데이터를 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${postLabel} 테이블`
+                        `${postLabel} + ${photoLabel} 테이블`
                     )}의 ${chalk.yellow(
                         `${id}번`
                     )} 데이터를 조회하는 중에 문제가 발생했습니다. ${chalk.dim(

--- a/routes/category.routes.js
+++ b/routes/category.routes.js
@@ -6,8 +6,8 @@ module.exports = (app) => {
     router.post("/", categories.create);
 
     router.get("/", categories.findAll);
-
     router.get("/:id", categories.findOne);
+    router.get("/post/:id", categories.findOneWithPost);
 
     router.put("/:id", categories.update);
 

--- a/routes/post.routes.js
+++ b/routes/post.routes.js
@@ -6,8 +6,8 @@ module.exports = (app) => {
     router.post("/", posts.create);
 
     router.get("/", posts.findAll);
-
     router.get("/:id", posts.findOne);
+    router.get("/user/:id", posts.findOneWithUser);
 
     router.put("/:id", posts.update);
 


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- Category 테이블과 Post 테이블에서 연관된 데이터를 동시에 조회하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- 특정 Category + Post + Photo 조회 (`categories.findOneWithPost`)
- 전체 Post + Photo 조회 (`posts.findAll`) => 기존 posts.findAll에서 2023.02.03 01:53 변경
- 특정 Post + Photo 조회 (~~`posts.findOneWithPhoto`~~ => `posts.findOne`) => 2023.02.03 01:53 변경
- 특정 Post 조회 (`posts.findOne`) 기능 삭제 => 2023.02.03 01:53 추가
- 특정 ~~Post + User + Photo~~ => Post + User + Worker + Photo 조회 (~~`posts.findOneWithUserAndPhoto`~~ => `posts.findOneWithUser`) => 2023.02.03 02:11 변경

## ToDo 📆 (남은 작업)
- [ ] 없음

## ScreenShot 📷 (참고 사진)
- 없음

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 드디어 관련 조회 기능은 다 끝났습니다. 후에 추가되거나 변경 가능성은 아직 있지만, 당장 계획했던 조회 기능은 모두 추가 되었네요.
- 이제 남은건 연관 데이터 한꺼번에 추가, 수정 기능만 남았습니다. 얼마 안남은 만큼 서버 빠르게 열심히 좀 해보겠습니다.
- 하지만.. 남은 기능이 어려운 기능들 뿐이라 또르륵...

## Reference 🔗
- 없음

## Close Issues 🔒 (닫을 Issue)
- Close #47.
