### PR TITLE
[!HOTFIX] 단일 데이터 조회시 배열 반환 문제

### DIFF
--- a/controllers/category.controller.js
+++ b/controllers/category.controller.js
@@ -192,7 +192,7 @@ exports.findOneWithPost = (req, res) => {
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
-        Category.findAll({
+        Category.findOne({
             where: { categoryID: id },
             order: [["categoryID", asc]],
             include: [

--- a/controllers/post.controller.js
+++ b/controllers/post.controller.js
@@ -143,7 +143,7 @@ exports.findOne = (req, res) => {
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
-        Post.findAll({
+        Post.findOne({
             where: { postID: id },
             include: [
                 {
@@ -197,7 +197,7 @@ exports.findOneWithUser = (req, res) => {
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
-        Post.findAll({
+        Post.findOne({
             where: { postID: id },
             attributes: [
                 "postID",

--- a/controllers/room.controller.js
+++ b/controllers/room.controller.js
@@ -249,7 +249,7 @@ exports.findOneWithCategory = (req, res) => {
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
-        Room.findAll({
+        Room.findOne({
             where: { roomID: id },
             order: [["roomID", asc]],
             include: [
@@ -304,7 +304,7 @@ exports.findOneWithPost = (req, res) => {
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
-        Room.findAll({
+        Room.findOne({
             where: { roomID: id },
             order: [["roomID", asc]],
             include: [
@@ -373,7 +373,7 @@ exports.findOneWithCategoryAndPost = (req, res) => {
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
-        Room.findAll({
+        Room.findOne({
             where: { roomID: id },
             order: [["roomID", asc]],
             include: [
@@ -449,7 +449,7 @@ exports.findOneWithPostAndCategory = (req, res) => {
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
-        Room.findAll({
+        Room.findOne({
             where: { roomID: id },
             order: [["roomID", asc]],
             include: [
@@ -523,7 +523,7 @@ exports.findOneWithUser = (req, res) => {
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
-        Room.findAll({
+        Room.findOne({
             where: { roomID: id },
             order: [["roomID", asc]],
             include: [

--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -122,7 +122,7 @@ exports.findOne = (req, res) => {
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
-        User.findAll({
+        User.findOne({
             where: { userID: id },
             include: [
                 {
@@ -176,7 +176,7 @@ exports.findOneWithRoom = (req, res) => {
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
-        User.findAll({
+        User.findOne({
             where: { userID: id },
             order: [["userID", asc]],
             include: [


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 단일 데이터를 조회할 때 단일 데이터가 아닌, 배열을 반환하는 문제를 해결하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- 단일 데이터 조회시 배열 반환 문제 해결

## ToDo 📆 (남은 작업)
- [ ] 없음

## ScreenShot 📷 (참고 사진)
|현재 반환|정상 반환|
|:-:|:-:|
|<img src="https://user-images.githubusercontent.com/81027256/216509764-197e8a7f-abad-4917-8885-ecc2a56adf57.png">|<img src="https://user-images.githubusercontent.com/81027256/216509827-855fb13c-f952-45de-873e-e6069c4aaef2.png">|

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 제가 실수로 join 테이블에서 단일 데이터 조회시에 배열을 반환하도록 코드를 짰네요.
- 해당 문제를 수정하기 위한 hotfix입니다. 크게 변한 부분은 없고 반환만 배열이 아닌 단일 데이터로 바꿨습니다.
- 가볍지만 빠르게 확인 부탁드립니다.

## Reference 🔗
- 없음

## Close Issues 🔒 (닫을 Issue)
- Close #52.
