### PR TITLE
[!HOTFIX] Worker 테이블의 userID 변경 시도시 변경되는 문제 해결

### DIFF
--- a/controllers/worker.controller.js
+++ b/controllers/worker.controller.js
@@ -50,7 +50,7 @@ exports.create = (req, res) => {
 
         Worker.create(worker)
             .then((data) => {
-                res.send(data);
+                res.status(200).send();
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${workerLabel} 테이블`
@@ -73,7 +73,7 @@ exports.create = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -90,7 +90,7 @@ exports.findAll = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Worker.findAll({ order: [["userID", asc]] })
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${workerLabel} 테이블`
@@ -113,7 +113,7 @@ exports.findAll = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -132,7 +132,7 @@ exports.findOne = (req, res) => {
         Worker.findByPk(id)
             .then((data) => {
                 if (data) {
-                    res.send(data);
+                    res.status(200).send(data);
                     console.log(
                         `[${moment().format(
                             dateFormat
@@ -143,7 +143,7 @@ exports.findOne = (req, res) => {
                         )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                     );
                 } else {
-                    res.status(400).send({
+                    res.status(404).send({
                         message: `${workerLabel} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
@@ -175,7 +175,7 @@ exports.findOne = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -217,7 +217,7 @@ exports.update = (req, res) => {
         })
             .then((data) => {
                 if (data[0] == 1) {
-                    res.send(data[1][0]);
+                    res.status(200).send(data[1][0]);
                     console.log(
                         `[${moment().format(
                             dateFormat
@@ -273,7 +273,7 @@ exports.update = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 "YYYY-MM-DD HH:mm:ss.SSS"

--- a/controllers/worker.controller.js
+++ b/controllers/worker.controller.js
@@ -206,7 +206,9 @@ exports.update = (req, res) => {
                     `${workerLabel} 테이블`
                 )}의 ${chalk.yellow(
                     `${id}번`
-                )} 데이터의 userID를 ${userID}로 변경할 수 없습니다. (IP: ${IP})`
+                )} 데이터의 userID를 ${chalk.yellow(
+                    userID
+                )}로 변경할 수 없습니다. (IP: ${IP})`
             );
             return;
         }

--- a/controllers/worker.controller.js
+++ b/controllers/worker.controller.js
@@ -145,7 +145,7 @@ exports.findOne = (req, res) => {
                     );
                 } else {
                     res.status(400).send({
-                        message: `${userLabel} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
+                        message: `${workerLabel} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(

--- a/controllers/worker.controller.js
+++ b/controllers/worker.controller.js
@@ -190,8 +190,25 @@ exports.findOne = (req, res) => {
 exports.update = (req, res) => {
     const id = req.params.id;
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
+    const userID = req.body.userID;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
+        if (userID) {
+            res.status(400).send({
+                message: `${workerLabel} 테이블의 ${id}번 데이터의 userID를 ${userID}로 변경할 수 없습니다.`,
+            });
+            console.log(
+                `[${moment().format(
+                    dateFormat
+                )}] ${badAccessError} ${chalk.yellow(
+                    `${workerLabel} 테이블`
+                )}의 ${chalk.yellow(
+                    `${id}번`
+                )} 데이터의 userID를 ${userID}로 변경할 수 없습니다. (IP: ${IP})`
+            );
+            return;
+        }
+
         Worker.update(req.body, {
             where: { userID: id },
             returning: true,

--- a/controllers/worker.controller.js
+++ b/controllers/worker.controller.js
@@ -191,6 +191,9 @@ exports.update = (req, res) => {
     const id = req.params.id;
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
     const userID = req.body.userID;
+    const userIdentifier = req.body.userIdentifier;
+    const name = req.body.name;
+    const email = req.body.email;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         if (userID) {
@@ -225,9 +228,9 @@ exports.update = (req, res) => {
                             `${id}번`
                         )} 데이터가 성공적으로 수정되었습니다. (IP: ${IP})`
                     );
-                } else {
-                    res.send({
-                        message: `${workerLabel} 테이블의 ${id}번 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다.`,
+                } else if (!userIdentifier && !name && !email) {
+                    res.status(400).send({
+                        message: `${workerLabel} 테이블의 ${id}번 데이터를 수정할 수 없습니다. request의 body가 비어있습니다.`,
                     });
                     console.log(
                         `[${moment().format(
@@ -236,7 +239,20 @@ exports.update = (req, res) => {
                             `${workerLabel} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
-                        )} 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다. (IP: ${IP})`
+                        )} 데이터를 수정할 수 없습니다. request의 body가 비어있습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${workerLabel} 테이블의 ${id}번 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${workerLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
                     );
                 }
             })

--- a/controllers/worker.controller.js
+++ b/controllers/worker.controller.js
@@ -12,7 +12,6 @@ const unknownError = `🟣${purple("Error:")}`;
 const reqHeaderIPField = "X-FORWARDED-FOR";
 const reqHeaderAPIKeyField = "API-Key";
 const asc = "ASC";
-const userLabel = "User";
 const workerLabel = "Worker";
 
 dotenv.config();


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- worker 테이블에서 PUT 메서드를 이용해 update를 시도할 시에, Worker 테이블의 userID가 변경되는 문제 발견
- 해당 문제는 User 테이블과 Worker 테이블의 정보가 서로 다른 사람의 정보를 매칭할 가능성이 존재함
- 해당 문제를 해결하기 위해 코드 변경

## Key Changes 🔥 (주요 구현/변경 사항)
- 단일 Worker 정보 조회시, 해당하는 userID의 Worker 정보가 없으면 User 테이블에서 데이터를 찾을 수 없다고 잘못 표기되는 문제 해결
- 단일 Worker 정보 수정시, userID를 변경하려고 시도하면 Worker 테이블의 userID가 변경되는 문제 해결 (198-214 라인)
- 단일 Worker 정보 수정시, Status Code를 더 상세하게 분류하여 반환하도록 변경
- Worker 테이블 메서드의 일부 Response Status Code를 더 목적에 맞는 Status Code로 변경
- Worker 테이블 메서드의 `200` 응답에 대한 부분을 명시적으로 표현

## ToDo 📆 (남은 작업)
- [ ] 일부 메서드에 Status Code 및 문제 상황 추가

## ScreenShot 📷 (참고 사진)
- 없음

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- User 테이블과 Worker 테이블이 같은 column을 pk로 잡고 있다는 것을 간과하고 Worker 테이블에서 Pk 수정을 막지 못했습니다.
- 해당 문제를 해결하기 위한 PR로 추가되는 코드가 길진 않으니 가볍게 확인해주셔도 괜찮습니다.
- 해당 문제에 대한 코드는 198~214 라인의 코드 입니다.

## Reference 🔗
- 없음

## Close Issues 🔒 (닫을 Issue)
Close #54.
