### PR TITLE
[Fix] 잘못된 Status Code 반환 및 부족한 네트워크 에러 핸들링 문제

### DIFF
--- a/controllers/category.controller.js
+++ b/controllers/category.controller.js
@@ -74,7 +74,7 @@ exports.create = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -114,7 +114,7 @@ exports.findAll = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -144,7 +144,7 @@ exports.findOne = (req, res) => {
                         )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                     );
                 } else {
-                    res.status(400).send({
+                    res.status(404).send({
                         message: `${categoryLabel} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
@@ -176,7 +176,7 @@ exports.findOne = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -245,7 +245,7 @@ exports.findOneWithPost = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -308,7 +308,7 @@ exports.update = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat

--- a/controllers/category.controller.js
+++ b/controllers/category.controller.js
@@ -218,14 +218,29 @@ exports.findOneWithPost = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
-                console.log(
-                    `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${categoryLabel} + ${postLabel} + ${photoLabel} 테이블`
-                    )}의 ${chalk.yellow(
-                        `categoryID=${id}`
-                    )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
-                );
+                if (data) {
+                    res.status(200).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${categoryLabel} + ${postLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `categoryID=${id}`
+                        )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${categoryLabel} + ${postLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `categoryID=${id}`
+                        )}인 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
             })
             .catch((err) => {
                 res.status(500).send({
@@ -259,6 +274,9 @@ exports.findOneWithPost = (req, res) => {
 exports.update = (req, res) => {
     const id = req.params.id;
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
+    const roomID = req.body.roomID;
+    const name = req.body.name;
+    const progress = req.body.progress;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Category.update(req.body, {
@@ -277,9 +295,22 @@ exports.update = (req, res) => {
                             `${id}번`
                         )} 데이터가 성공적으로 수정되었습니다. (IP: ${IP})`
                     );
+                } else if (!roomID && !name && !progress) {
+                    res.status(400).send({
+                        message: `${categoryLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${categoryLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다. (IP: ${IP})`
+                    );
                 } else {
-                    res.send({
-                        message: `${categoryLabel} 테이블의 ${id}번 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다.`,
+                    res.status(404).send({
+                        message: `${categoryLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없있습니다.`,
                     });
                     console.log(
                         `[${moment().format(

--- a/controllers/category.controller.js
+++ b/controllers/category.controller.js
@@ -51,7 +51,7 @@ exports.create = (req, res) => {
 
         Category.create(category)
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${categoryLabel} 테이블`
@@ -91,7 +91,7 @@ exports.findAll = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Category.findAll({ order: [["categoryID", asc]] })
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${categoryLabel} 테이블`
@@ -133,7 +133,7 @@ exports.findOne = (req, res) => {
         Category.findByPk(id)
             .then((data) => {
                 if (data) {
-                    res.send(data);
+                    res.status(200).send(data);
                     console.log(
                         `[${moment().format(
                             dateFormat
@@ -267,7 +267,7 @@ exports.update = (req, res) => {
         })
             .then((data) => {
                 if (data[0] == 1) {
-                    res.send(data[1][0]);
+                    res.status(200).send(data[1][0]);
                     console.log(
                         `[${moment().format(
                             dateFormat

--- a/controllers/category.controller.js
+++ b/controllers/category.controller.js
@@ -288,7 +288,7 @@ exports.update = (req, res) => {
                             `${categoryLabel} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
-                        )} 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다. (IP: ${IP})`
+                        )} 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
                     );
                 }
             })

--- a/controllers/photo.controller.js
+++ b/controllers/photo.controller.js
@@ -46,7 +46,7 @@ exports.create = (req, res) => {
 
         Photo.create(photo)
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${photoLabel} 테이블`
@@ -86,7 +86,7 @@ exports.findAll = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Photo.findAll({ order: [["photoID", asc]] })
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${photoLabel} 테이블`
@@ -128,7 +128,7 @@ exports.findOne = (req, res) => {
         Photo.findByPk(id)
             .then((data) => {
                 if (data) {
-                    res.send(data);
+                    res.status(200).send(data);
                     console.log(
                         `[${moment().format(
                             dateFormat
@@ -193,7 +193,7 @@ exports.update = (req, res) => {
         })
             .then((data) => {
                 if (data[0] == 1) {
-                    res.send(data[1][0]);
+                    res.status(200).send(data[1][0]);
                     console.log(
                         `[${moment().format(
                             dateFormat

--- a/controllers/photo.controller.js
+++ b/controllers/photo.controller.js
@@ -69,7 +69,7 @@ exports.create = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -109,7 +109,7 @@ exports.findAll = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -139,7 +139,7 @@ exports.findOne = (req, res) => {
                         )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                     );
                 } else {
-                    res.status(400).send({
+                    res.status(404).send({
                         message: `${photoLabel} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
@@ -236,7 +236,7 @@ exports.update = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat

--- a/controllers/photo.controller.js
+++ b/controllers/photo.controller.js
@@ -171,7 +171,7 @@ exports.findOne = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -185,6 +185,8 @@ exports.findOne = (req, res) => {
 exports.update = (req, res) => {
     const id = req.params.id;
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
+    const postID = req.body.postID;
+    const url = req.body.url;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Photo.update(req.body, {
@@ -203,9 +205,9 @@ exports.update = (req, res) => {
                             `${id}번`
                         )} 데이터가 성공적으로 수정되었습니다. (IP: ${IP})`
                     );
-                } else {
-                    res.send({
-                        message: `${photoLabel} 테이블의 ${id}번 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다.`,
+                } else if (!postID && !url) {
+                    res.status(400).send({
+                        message: `${photoLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
@@ -214,7 +216,20 @@ exports.update = (req, res) => {
                             `${photoLabel} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
-                        )} 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다. (IP: ${IP})`
+                        )} 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${photoLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
                     );
                 }
             })

--- a/controllers/post.controller.js
+++ b/controllers/post.controller.js
@@ -55,7 +55,7 @@ exports.create = (req, res) => {
 
         Post.create(post)
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${postLabel} 테이블`
@@ -104,7 +104,7 @@ exports.findAll = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${postLabel} + ${photoLabel} 테이블`
@@ -278,7 +278,7 @@ exports.update = (req, res) => {
         })
             .then((data) => {
                 if (data[0] == 1) {
-                    res.send(data[1][0]);
+                    res.status(200).send(data[1][0]);
                     console.log(
                         `[${moment().format(
                             dateFormat

--- a/controllers/post.controller.js
+++ b/controllers/post.controller.js
@@ -154,14 +154,29 @@ exports.findOne = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
-                console.log(
-                    `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${postLabel} + ${photoLabel} 테이블`
-                    )}의 ${chalk.yellow(
-                        `${id}번`
-                    )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
-                );
+                if (data) {
+                    res.status(200).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${postLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${postLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
             })
             .catch((err) => {
                 res.status(500).send({
@@ -229,14 +244,29 @@ exports.findOneWithUser = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
-                console.log(
-                    `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${postLabel} + ${userLabel} + ${workerLabel} + ${photoLabel} 테이블`
-                    )}의 ${chalk.yellow(
-                        `postID=${id}`
-                    )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
-                );
+                if (data) {
+                    res.status(200).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${postLabel} + ${userLabel} + ${workerLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `postID=${id}`
+                        )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${postLabel} + ${userLabel} + ${workerLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `postID=${id}`
+                        )}인 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
             })
             .catch((err) => {
                 res.status(500).send({
@@ -270,8 +300,31 @@ exports.findOneWithUser = (req, res) => {
 exports.update = (req, res) => {
     const id = req.params.id;
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
+    const roomID = req.body.roomID;
+    const userID = req.body.userID;
+    const categoryID = req.body.categoryID;
+    const description = req.body.description;
+    const createDate = req.body.createDate;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
+        if (createDate) {
+            res.status(400).send({
+                message: `${postLabel} 테이블의 ${id}번 데이터의 createDate를 ${createDate}로 변경할 수 없습니다.`,
+            });
+            console.log(
+                `[${moment().format(
+                    dateFormat
+                )}] ${badAccessError} ${chalk.yellow(
+                    `${postLabel} 테이블`
+                )}의 ${chalk.yellow(
+                    `${id}번`
+                )} 데이터의 createDate를 ${chalk.yellow(
+                    createDate
+                )}로 변경할 수 없습니다. (IP: ${IP})`
+            );
+            return;
+        }
+
         Post.update(req.body, {
             where: { postID: id },
             returning: true,
@@ -288,9 +341,9 @@ exports.update = (req, res) => {
                             `${id}번`
                         )} 데이터가 성공적으로 수정되었습니다. (IP: ${IP})`
                     );
-                } else {
-                    res.send({
-                        message: `${postLabel} 테이블의 ${id}번 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다.`,
+                } else if (!roomID && !userID && !categoryID && !description) {
+                    res.status(400).send({
+                        message: `${postLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
@@ -299,7 +352,20 @@ exports.update = (req, res) => {
                             `${postLabel} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
-                        )} 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다. (IP: ${IP})`
+                        )} 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${postLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${postLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
                     );
                 }
             })

--- a/controllers/post.controller.js
+++ b/controllers/post.controller.js
@@ -78,7 +78,7 @@ exports.create = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -127,7 +127,7 @@ exports.findAll = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -181,7 +181,7 @@ exports.findOne = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -256,7 +256,7 @@ exports.findOneWithUser = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -321,7 +321,7 @@ exports.update = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat

--- a/controllers/room.controller.js
+++ b/controllers/room.controller.js
@@ -261,14 +261,31 @@ exports.findOneWithCategory = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
-                console.log(
-                    `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${roomLabel} + ${categoryLabel} 테이블`
-                    )}의 ${chalk.yellow(
-                        `roomID=${id}`
-                    )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
-                );
+                if (data) {
+                    res.status(200).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${roomLabel} + ${categoryLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `roomID=${id}`
+                        )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${roomLabel} + ${categoryLabel} 테이블에서 roomID=${id}인 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${roomLabel} + ${categoryLabel} 테이블`
+                        )}에서 ${chalk.yellow(
+                            `roomID=${id}`
+                        )}인 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
             })
             .catch((err) => {
                 res.status(500).send({
@@ -330,14 +347,29 @@ exports.findOneWithPost = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
-                console.log(
-                    `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${roomLabel} + ${postLabel} + ${photoLabel} 테이블`
-                    )}의 ${chalk.yellow(
-                        `roomID=${id}`
-                    )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
-                );
+                if (data) {
+                    res.status(200).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${roomLabel} + ${postLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `roomID=${id}`
+                        )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${roomLabel} + ${postLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `roomID=${id}`
+                        )}인 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
             })
             .catch((err) => {
                 res.status(500).send({
@@ -406,14 +438,29 @@ exports.findOneWithCategoryAndPost = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
-                console.log(
-                    `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${roomLabel} + ${categoryLabel} + ${postLabel} + ${photoLabel} 테이블`
-                    )}의 ${chalk.yellow(
-                        `roomID=${id}`
-                    )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
-                );
+                if (data) {
+                    res.status(200).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${roomLabel} + ${categoryLabel} + ${postLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `roomID=${id}`
+                        )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${roomLabel} + ${categoryLabel} + ${postLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `roomID=${id}`
+                        )}인 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
             })
             .catch((err) => {
                 res.status(500).send({
@@ -480,14 +527,29 @@ exports.findOneWithPostAndCategory = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
-                console.log(
-                    `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${roomLabel} + ${postLabel} + ${categoryLabel} + ${photoLabel} 테이블`
-                    )}의 ${chalk.yellow(
-                        `roomID=${id}`
-                    )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
-                );
+                if (data) {
+                    res.status(200).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${roomLabel} + ${postLabel} + ${categoryLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `roomID=${id}`
+                        )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${roomLabel} + ${postLabel} + ${categoryLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `roomID=${id}`
+                        )}인 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
             })
             .catch((err) => {
                 res.status(500).send({
@@ -555,14 +617,29 @@ exports.findOneWithUser = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
-                console.log(
-                    `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${roomLabel} + ${userroomLabel} + ${userLabel} + ${workerLabel} 테이블`
-                    )}의 ${chalk.yellow(
-                        `roomID=${id}`
-                    )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
-                );
+                if (data) {
+                    res.status(200).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${roomLabel} + ${userroomLabel} + ${userLabel} + ${workerLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `roomID=${id}`
+                        )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${roomLabel} + ${userroomLabel} + ${userLabel} + ${workerLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `roomID=${id}`
+                        )}인 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
             })
             .catch((err) => {
                 res.status(500).send({
@@ -596,8 +673,31 @@ exports.findOneWithUser = (req, res) => {
 exports.update = (req, res) => {
     const id = req.params.id;
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
+    const name = req.body.name;
+    const startDate = req.body.startDate;
+    const endDate = req.body.endDate;
+    const warrantyTime = req.body.warrantyTime;
+    const inviteCode = req.body.inviteCode;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
+        if (inviteCode) {
+            res.status(400).send({
+                message: `${roomLabel} 테이블의 ${id}번 데이터의 inviteCode를 ${inviteCode}로 변경할 수 없습니다.`,
+            });
+            console.log(
+                `[${moment().format(
+                    dateFormat
+                )}] ${badAccessError} ${chalk.yellow(
+                    `${roomLabel} 테이블`
+                )}의 ${chalk.yellow(
+                    `${id}번`
+                )} 데이터의 inviteCode를 ${chalk.yellow(
+                    inviteCode
+                )}로 변경할 수 없습니다. (IP: ${IP})`
+            );
+            return;
+        }
+
         Room.update(req.body, {
             where: { roomID: id },
             returning: true,
@@ -614,9 +714,9 @@ exports.update = (req, res) => {
                             `${id}번`
                         )} 데이터가 성공적으로 수정되었습니다. (IP: ${IP})`
                     );
-                } else {
-                    res.send({
-                        message: `${roomLabel} 테이블의 ${id}번 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다.`,
+                } else if (!name && !startDate && !endDate && !warrantyTime) {
+                    res.status(400).send({
+                        message: `${roomLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
@@ -625,7 +725,20 @@ exports.update = (req, res) => {
                             `${roomLabel} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
-                        )} 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다. (IP: ${IP})`
+                        )} 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${roomLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${roomLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
                     );
                 }
             })

--- a/controllers/room.controller.js
+++ b/controllers/room.controller.js
@@ -131,7 +131,7 @@ exports.create = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -171,7 +171,7 @@ exports.findAll = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -201,7 +201,7 @@ exports.findOne = (req, res) => {
                         )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                     );
                 } else {
-                    res.status(400).send({
+                    res.status(404).send({
                         message: `${roomLabel} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
@@ -233,7 +233,7 @@ exports.findOne = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -288,7 +288,7 @@ exports.findOneWithCategory = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -357,7 +357,7 @@ exports.findOneWithPost = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -433,7 +433,7 @@ exports.findOneWithCategoryAndPost = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -507,7 +507,7 @@ exports.findOneWithPostAndCategory = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -582,7 +582,7 @@ exports.findOneWithUser = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -647,7 +647,7 @@ exports.update = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat

--- a/controllers/room.controller.js
+++ b/controllers/room.controller.js
@@ -108,7 +108,7 @@ exports.create = (req, res) => {
 
         Room.create(room)
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${roomLabel} 테이블`
@@ -148,7 +148,7 @@ exports.findAll = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Room.findAll({ order: [["roomID", asc]] })
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${roomLabel} 테이블`
@@ -190,7 +190,7 @@ exports.findOne = (req, res) => {
         Room.findByPk(id)
             .then((data) => {
                 if (data) {
-                    res.send(data);
+                    res.status(200).send(data);
                     console.log(
                         `[${moment().format(
                             dateFormat
@@ -604,7 +604,7 @@ exports.update = (req, res) => {
         })
             .then((data) => {
                 if (data[0] == 1) {
-                    res.send(data[1][0]);
+                    res.status(200).send(data[1][0]);
                     console.log(
                         `[${moment().format(
                             dateFormat

--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -133,14 +133,31 @@ exports.findOne = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
-                console.log(
-                    `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${userLabel} + ${workerLabel} 테이블`
-                    )}의 ${chalk.yellow(
-                        `${id}번`
-                    )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
-                );
+                if (data) {
+                    res.status(200).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${userLabel} + ${workerLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${userLabel} + ${workerLabel} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${userLabel} + ${workerLabel} 테이블`
+                        )}에서 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
             })
             .catch((err) => {
                 res.status(500).send({
@@ -207,14 +224,31 @@ exports.findOneWithRoom = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
-                console.log(
-                    `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${userLabel} + ${workerLabel} + ${userroomLabel} + ${roomLabel} 테이블`
-                    )}의 ${chalk.yellow(
-                        `userID=${id}`
-                    )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
-                );
+                if (data) {
+                    res.status(200).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${userLabel} + ${workerLabel} + ${userroomLabel} + ${roomLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `userID=${id}`
+                        )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${userLabel} + ${workerLabel} + ${userroomLabel} + ${roomLabel} 테이블에서 userID=${id}인 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${userLabel} + ${workerLabel} + ${userroomLabel} + ${roomLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `userID=${id}`
+                        )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                    );
+                }
             })
             .catch((err) => {
                 res.status(500).send({
@@ -248,6 +282,7 @@ exports.findOneWithRoom = (req, res) => {
 exports.update = (req, res) => {
     const id = req.params.id;
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
+    const number = req.body.number;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         User.update(req.body, {
@@ -266,9 +301,9 @@ exports.update = (req, res) => {
                             `${id}번`
                         )} 데이터가 성공적으로 수정되었습니다. (IP: ${IP})`
                     );
-                } else {
-                    res.send({
-                        message: `${userLabel} 테이블의 ${id}번 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다.`,
+                } else if (!number) {
+                    res.status(400).send({
+                        message: `${userLabel} 테이블의 ${id}번 데이터의 수정을 시도했지만, request의 body가 비어있어 수정할 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
@@ -277,7 +312,20 @@ exports.update = (req, res) => {
                             `${userLabel} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
-                        )} 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다. (IP: ${IP})`
+                        )} 데이터의 수정을 시도했지만, request의 body가 비어있어 수정할 수 없습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${userLabel} 테이블의 ${id}번 데이터의 수정을 시도했지만, 해당 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${userLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터의 수정을 시도했지만, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
                     );
                 }
             })

--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -34,7 +34,7 @@ exports.create = (req, res) => {
 
         User.create(user)
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${userLabel} 테이블`
@@ -83,7 +83,7 @@ exports.findAll = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${userLabel} + ${workerLabel} 테이블`
@@ -256,7 +256,7 @@ exports.update = (req, res) => {
         })
             .then((data) => {
                 if (data[0] == 1) {
-                    res.send(data[1][0]);
+                    res.status(200).send(data[1][0]);
                     console.log(
                         `[${moment().format(
                             dateFormat

--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -57,7 +57,7 @@ exports.create = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -106,7 +106,7 @@ exports.findAll = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -160,7 +160,7 @@ exports.findOne = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -234,7 +234,7 @@ exports.findOneWithRoom = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -299,7 +299,7 @@ exports.update = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat

--- a/controllers/userroom.controller.js
+++ b/controllers/userroom.controller.js
@@ -46,7 +46,7 @@ exports.create = (req, res) => {
 
         UserRoom.create(userroom)
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${userroomLabel} 테이블`
@@ -86,7 +86,7 @@ exports.findAll = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         UserRoom.findAll({ order: [["userRoomID", asc]] })
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${userroomLabel} 테이블`
@@ -193,7 +193,7 @@ exports.update = (req, res) => {
         })
             .then((data) => {
                 if (data[0] == 1) {
-                    res.send(data[1][0]);
+                    res.status(200).send(data[1][0]);
                     console.log(
                         `[${moment().format(
                             dateFormat

--- a/controllers/userroom.controller.js
+++ b/controllers/userroom.controller.js
@@ -69,7 +69,7 @@ exports.create = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -109,7 +109,7 @@ exports.findAll = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -139,7 +139,7 @@ exports.findOne = (req, res) => {
                         )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                     );
                 } else {
-                    res.status(400).send({
+                    res.status(404).send({
                         message: `${userroomLabel} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
@@ -171,7 +171,7 @@ exports.findOne = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -236,7 +236,7 @@ exports.update = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat

--- a/controllers/userroom.controller.js
+++ b/controllers/userroom.controller.js
@@ -185,6 +185,8 @@ exports.findOne = (req, res) => {
 exports.update = (req, res) => {
     const id = req.params.id;
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
+    const userID = req.body.userID;
+    const roomID = req.body.roomID;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         UserRoom.update(req.body, {
@@ -203,9 +205,9 @@ exports.update = (req, res) => {
                             `${id}번`
                         )} 데이터가 성공적으로 수정되었습니다. (IP: ${IP})`
                     );
-                } else {
-                    res.send({
-                        message: `U${userroomLabel} 테이블의 ${id}번 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다.`,
+                } else if (!userID && !roomID) {
+                    res.status(400).send({
+                        message: `U${userroomLabel} 테이블의 ${id}번 데이터의 수정을 시도했지만, request의 body가 비어있어 수정할 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
@@ -214,7 +216,20 @@ exports.update = (req, res) => {
                             `${userroomLabel} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
-                        )} 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다. (IP: ${IP})`
+                        )} 데이터의 수정을 시도했지만, request의 body가 비어있어 수정할 수 없습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${userroomLabel} 테이블의 ${id}번 데이터의 수정을 시도했지만, 해당 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${userroomLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터의 수정을 시도했지만, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
                     );
                 }
             })

--- a/controllers/worker.controller.js
+++ b/controllers/worker.controller.js
@@ -231,7 +231,7 @@ exports.update = (req, res) => {
                     );
                 } else if (!userIdentifier && !name && !email) {
                     res.status(400).send({
-                        message: `${workerLabel} 테이블의 ${id}번 데이터를 수정할 수 없습니다. request의 body가 비어있습니다.`,
+                        message: `${workerLabel} 테이블의 ${id}번 데이터의 수정을 시도했지만, request의 body가 비어있어 수정할 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
@@ -240,11 +240,11 @@ exports.update = (req, res) => {
                             `${workerLabel} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
-                        )} 데이터를 수정할 수 없습니다. request의 body가 비어있습니다. (IP: ${IP})`
+                        )} 데이터의 수정을 시도했지만, request의 body가 비어있어 수정할 수 없습니다. (IP: ${IP})`
                     );
                 } else {
                     res.status(404).send({
-                        message: `${workerLabel} 테이블의 ${id}번 데이터를 찾을 수 없습니다.`,
+                        message: `${workerLabel} 테이블의 ${id}번 데이터의 수정을 시도했지만, 해당 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
@@ -253,7 +253,7 @@ exports.update = (req, res) => {
                             `${workerLabel} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
-                        )} 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                        )} 데이터의 수정을 시도했지만, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
                     );
                 }
             })

--- a/controllers/worker.controller.js
+++ b/controllers/worker.controller.js
@@ -50,7 +50,7 @@ exports.create = (req, res) => {
 
         Worker.create(worker)
             .then((data) => {
-                res.status(200).send();
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${workerLabel} 테이블`


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 잘못된 Status Code를 반환하는 문제를 해결하기 위함
- 일부 네트워크 에러에 대해 더 자세히 핸들링 하지 않고, `500`번으로 퉁치는 문제 해결

## Key Changes 🔥 (주요 구현/변경 사항)
- 잘못된 Status Code를 반환하고 있던 일부 메서드의 Status Code 변경
  - 모든 메서드들의 `Connection Fail` Status Code가 `401  Unauthorized`에서 `403 Forbidden`으로 변경
  - 모든 테이블의 단일 데이터 조회 메서드에서 해당 데이터가 없을 때, `400 Bad Request` 혹은 `200 OK`를 반환하고 있던 부분 `404 Not Found`로 변경
- 더 다양한 네트워크 에러 핸들링
  - 모든 테이블의 update 메서드에서 데이터를 찾을 수 없거나, request body가 비어있을 때를 한번에 처리하고 있던 부분을 request body가 비어 있을 때는 `400 Bad Request`로, 데이터를 찾을 수 없을 때는 `404 Not Found`로 반환하도록 세분화
- Worker에서 Create시 새로 생성된 데이터를 반환하지 않는 문제 해결
- 일부 로그 메시지 수정
  - Worker 테이블의 반영되지 못한 일부 로그 메시지 수정
- 요청이 성공적으로 들어왔을 시 코드에서도 명확하게 `200 OK`를 반환하고 있다는 것을 명시

## ToDo 📆 (남은 작업)
- [ ] 없음

## ScreenShot 📷 (참고 사진)
- 없음

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 일부 Status Code가 잘못되어 있던 부분, 일부 네트워크 에러가 대충 하나로 퉁쳐져 있던 부분을 전부 수정했습니다.
- 새로운 태스크를 빠르게 수행하는 것도 중요하지만, 기존의 코드에서 문제가 있는 곳을 먼저 해결하는 것이 클라이언트 수정 소요를 줄일 것이라고 판단하여 해당 부분 먼저 수정했습니다.
- 전체 코드를 봐가면서 추가, 수정한지라 라인의 수가 많습니다. 양해 부탁드립니다.
- 혹시 필요할까 싶어서 상태 코드에 대해 대략적으로 정리된 레퍼런스를 첨부합니다.

## Reference 🔗
- [WhaTap - HTTP 상태 코드 정리](https://www.whatap.io/ko/blog/40/)

## Close Issues 🔒 (닫을 Issue)
- Close #56.
