### PR TITLE
[!HOTFIX] 병합된 데이터 테이블의 데이터 순서 정렬이 제대로 되고 있지 않는 문제

### DIFF
--- a/controllers/category.controller.js
+++ b/controllers/category.controller.js
@@ -194,7 +194,7 @@ exports.findOneWithPost = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Category.findOne({
             where: { categoryID: id },
-            order: [["categoryID", asc]],
+            order: [[Post, "postID", asc]],
             include: [
                 {
                     model: Post,
@@ -206,7 +206,7 @@ exports.findOneWithPost = (req, res) => {
                         "description",
                         "createDate",
                     ],
-                    order: [["postID", asc]],
+                    order: [[Photo, "photoID", asc]],
                     include: [
                         {
                             model: Photo,

--- a/controllers/photo.controller.js
+++ b/controllers/photo.controller.js
@@ -46,7 +46,7 @@ exports.create = (req, res) => {
 
         Photo.create(photo)
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${photoLabel} 테이블`
@@ -69,7 +69,7 @@ exports.create = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -86,7 +86,7 @@ exports.findAll = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Photo.findAll({ order: [["photoID", asc]] })
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${photoLabel} 테이블`
@@ -109,7 +109,7 @@ exports.findAll = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -128,7 +128,7 @@ exports.findOne = (req, res) => {
         Photo.findByPk(id)
             .then((data) => {
                 if (data) {
-                    res.send(data);
+                    res.status(200).send(data);
                     console.log(
                         `[${moment().format(
                             dateFormat
@@ -139,7 +139,7 @@ exports.findOne = (req, res) => {
                         )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                     );
                 } else {
-                    res.status(400).send({
+                    res.status(404).send({
                         message: `${photoLabel} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
@@ -171,7 +171,7 @@ exports.findOne = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -185,6 +185,8 @@ exports.findOne = (req, res) => {
 exports.update = (req, res) => {
     const id = req.params.id;
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
+    const postID = req.body.postID;
+    const url = req.body.url;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Photo.update(req.body, {
@@ -193,7 +195,7 @@ exports.update = (req, res) => {
         })
             .then((data) => {
                 if (data[0] == 1) {
-                    res.send(data[1][0]);
+                    res.status(200).send(data[1][0]);
                     console.log(
                         `[${moment().format(
                             dateFormat
@@ -203,9 +205,9 @@ exports.update = (req, res) => {
                             `${id}번`
                         )} 데이터가 성공적으로 수정되었습니다. (IP: ${IP})`
                     );
-                } else {
-                    res.send({
-                        message: `${photoLabel} 테이블의 ${id}번 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다.`,
+                } else if (!postID && !url) {
+                    res.status(400).send({
+                        message: `${photoLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
@@ -214,7 +216,20 @@ exports.update = (req, res) => {
                             `${photoLabel} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
-                        )} 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다. (IP: ${IP})`
+                        )} 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${photoLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
                     );
                 }
             })
@@ -236,7 +251,7 @@ exports.update = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat

--- a/controllers/post.controller.js
+++ b/controllers/post.controller.js
@@ -55,7 +55,7 @@ exports.create = (req, res) => {
 
         Post.create(post)
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${postLabel} 테이블`
@@ -78,7 +78,7 @@ exports.create = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -104,7 +104,7 @@ exports.findAll = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${postLabel} + ${photoLabel} 테이블`
@@ -127,7 +127,7 @@ exports.findAll = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -154,14 +154,29 @@ exports.findOne = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
-                console.log(
-                    `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${postLabel} + ${photoLabel} 테이블`
-                    )}의 ${chalk.yellow(
-                        `${id}번`
-                    )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
-                );
+                if (data) {
+                    res.status(200).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${postLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${postLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
             })
             .catch((err) => {
                 res.status(500).send({
@@ -181,7 +196,7 @@ exports.findOne = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -229,14 +244,29 @@ exports.findOneWithUser = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
-                console.log(
-                    `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${postLabel} + ${userLabel} + ${workerLabel} + ${photoLabel} 테이블`
-                    )}의 ${chalk.yellow(
-                        `postID=${id}`
-                    )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
-                );
+                if (data) {
+                    res.status(200).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${postLabel} + ${userLabel} + ${workerLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `postID=${id}`
+                        )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${postLabel} + ${userLabel} + ${workerLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `postID=${id}`
+                        )}인 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
             })
             .catch((err) => {
                 res.status(500).send({
@@ -256,7 +286,7 @@ exports.findOneWithUser = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -270,15 +300,38 @@ exports.findOneWithUser = (req, res) => {
 exports.update = (req, res) => {
     const id = req.params.id;
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
+    const roomID = req.body.roomID;
+    const userID = req.body.userID;
+    const categoryID = req.body.categoryID;
+    const description = req.body.description;
+    const createDate = req.body.createDate;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
+        if (createDate) {
+            res.status(400).send({
+                message: `${postLabel} 테이블의 ${id}번 데이터의 createDate를 ${createDate}로 변경할 수 없습니다.`,
+            });
+            console.log(
+                `[${moment().format(
+                    dateFormat
+                )}] ${badAccessError} ${chalk.yellow(
+                    `${postLabel} 테이블`
+                )}의 ${chalk.yellow(
+                    `${id}번`
+                )} 데이터의 createDate를 ${chalk.yellow(
+                    createDate
+                )}로 변경할 수 없습니다. (IP: ${IP})`
+            );
+            return;
+        }
+
         Post.update(req.body, {
             where: { postID: id },
             returning: true,
         })
             .then((data) => {
                 if (data[0] == 1) {
-                    res.send(data[1][0]);
+                    res.status(200).send(data[1][0]);
                     console.log(
                         `[${moment().format(
                             dateFormat
@@ -288,9 +341,9 @@ exports.update = (req, res) => {
                             `${id}번`
                         )} 데이터가 성공적으로 수정되었습니다. (IP: ${IP})`
                     );
-                } else {
-                    res.send({
-                        message: `${postLabel} 테이블의 ${id}번 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다.`,
+                } else if (!roomID && !userID && !categoryID && !description) {
+                    res.status(400).send({
+                        message: `${postLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
@@ -299,7 +352,20 @@ exports.update = (req, res) => {
                             `${postLabel} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
-                        )} 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다. (IP: ${IP})`
+                        )} 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${postLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${postLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
                     );
                 }
             })
@@ -321,7 +387,7 @@ exports.update = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat

--- a/controllers/post.controller.js
+++ b/controllers/post.controller.js
@@ -94,7 +94,10 @@ exports.findAll = (req, res) => {
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Post.findAll({
-            order: [["postID", asc]],
+            order: [
+                ["postID", asc],
+                [Photo, "photoID", asc],
+            ],
             include: [
                 {
                     model: Photo,
@@ -145,6 +148,7 @@ exports.findOne = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Post.findOne({
             where: { postID: id },
+            order: [[Photo, "photoID", asc]],
             include: [
                 {
                     model: Photo,
@@ -221,7 +225,10 @@ exports.findOneWithUser = (req, res) => {
                 "description",
                 "createDate",
             ],
-            order: [["postID", asc]],
+            order: [
+                [User, "userID", asc],
+                [Photo, "photoID", asc],
+            ],
             include: [
                 {
                     model: User,

--- a/controllers/room.controller.js
+++ b/controllers/room.controller.js
@@ -108,7 +108,7 @@ exports.create = (req, res) => {
 
         Room.create(room)
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${roomLabel} 테이블`
@@ -131,7 +131,7 @@ exports.create = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -148,7 +148,7 @@ exports.findAll = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Room.findAll({ order: [["roomID", asc]] })
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${roomLabel} 테이블`
@@ -171,7 +171,7 @@ exports.findAll = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -190,7 +190,7 @@ exports.findOne = (req, res) => {
         Room.findByPk(id)
             .then((data) => {
                 if (data) {
-                    res.send(data);
+                    res.status(200).send(data);
                     console.log(
                         `[${moment().format(
                             dateFormat
@@ -201,7 +201,7 @@ exports.findOne = (req, res) => {
                         )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                     );
                 } else {
-                    res.status(400).send({
+                    res.status(404).send({
                         message: `${roomLabel} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
@@ -233,7 +233,7 @@ exports.findOne = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -261,14 +261,31 @@ exports.findOneWithCategory = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
-                console.log(
-                    `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${roomLabel} + ${categoryLabel} 테이블`
-                    )}의 ${chalk.yellow(
-                        `roomID=${id}`
-                    )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
-                );
+                if (data) {
+                    res.status(200).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${roomLabel} + ${categoryLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `roomID=${id}`
+                        )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${roomLabel} + ${categoryLabel} 테이블에서 roomID=${id}인 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${roomLabel} + ${categoryLabel} 테이블`
+                        )}에서 ${chalk.yellow(
+                            `roomID=${id}`
+                        )}인 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
             })
             .catch((err) => {
                 res.status(500).send({
@@ -288,7 +305,7 @@ exports.findOneWithCategory = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -330,14 +347,29 @@ exports.findOneWithPost = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
-                console.log(
-                    `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${roomLabel} + ${postLabel} + ${photoLabel} 테이블`
-                    )}의 ${chalk.yellow(
-                        `roomID=${id}`
-                    )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
-                );
+                if (data) {
+                    res.status(200).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${roomLabel} + ${postLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `roomID=${id}`
+                        )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${roomLabel} + ${postLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `roomID=${id}`
+                        )}인 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
             })
             .catch((err) => {
                 res.status(500).send({
@@ -357,7 +389,7 @@ exports.findOneWithPost = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -406,14 +438,29 @@ exports.findOneWithCategoryAndPost = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
-                console.log(
-                    `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${roomLabel} + ${categoryLabel} + ${postLabel} + ${photoLabel} 테이블`
-                    )}의 ${chalk.yellow(
-                        `roomID=${id}`
-                    )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
-                );
+                if (data) {
+                    res.status(200).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${roomLabel} + ${categoryLabel} + ${postLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `roomID=${id}`
+                        )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${roomLabel} + ${categoryLabel} + ${postLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `roomID=${id}`
+                        )}인 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
             })
             .catch((err) => {
                 res.status(500).send({
@@ -433,7 +480,7 @@ exports.findOneWithCategoryAndPost = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -480,14 +527,29 @@ exports.findOneWithPostAndCategory = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
-                console.log(
-                    `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${roomLabel} + ${postLabel} + ${categoryLabel} + ${photoLabel} 테이블`
-                    )}의 ${chalk.yellow(
-                        `roomID=${id}`
-                    )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
-                );
+                if (data) {
+                    res.status(200).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${roomLabel} + ${postLabel} + ${categoryLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `roomID=${id}`
+                        )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${roomLabel} + ${postLabel} + ${categoryLabel} + ${photoLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `roomID=${id}`
+                        )}인 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
             })
             .catch((err) => {
                 res.status(500).send({
@@ -507,7 +569,7 @@ exports.findOneWithPostAndCategory = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -555,14 +617,29 @@ exports.findOneWithUser = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
-                console.log(
-                    `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${roomLabel} + ${userroomLabel} + ${userLabel} + ${workerLabel} 테이블`
-                    )}의 ${chalk.yellow(
-                        `roomID=${id}`
-                    )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
-                );
+                if (data) {
+                    res.status(200).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${roomLabel} + ${userroomLabel} + ${userLabel} + ${workerLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `roomID=${id}`
+                        )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${roomLabel} + ${userroomLabel} + ${userLabel} + ${workerLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `roomID=${id}`
+                        )}인 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
             })
             .catch((err) => {
                 res.status(500).send({
@@ -582,7 +659,7 @@ exports.findOneWithUser = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -596,15 +673,38 @@ exports.findOneWithUser = (req, res) => {
 exports.update = (req, res) => {
     const id = req.params.id;
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
+    const name = req.body.name;
+    const startDate = req.body.startDate;
+    const endDate = req.body.endDate;
+    const warrantyTime = req.body.warrantyTime;
+    const inviteCode = req.body.inviteCode;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
+        if (inviteCode) {
+            res.status(400).send({
+                message: `${roomLabel} 테이블의 ${id}번 데이터의 inviteCode를 ${inviteCode}로 변경할 수 없습니다.`,
+            });
+            console.log(
+                `[${moment().format(
+                    dateFormat
+                )}] ${badAccessError} ${chalk.yellow(
+                    `${roomLabel} 테이블`
+                )}의 ${chalk.yellow(
+                    `${id}번`
+                )} 데이터의 inviteCode를 ${chalk.yellow(
+                    inviteCode
+                )}로 변경할 수 없습니다. (IP: ${IP})`
+            );
+            return;
+        }
+
         Room.update(req.body, {
             where: { roomID: id },
             returning: true,
         })
             .then((data) => {
                 if (data[0] == 1) {
-                    res.send(data[1][0]);
+                    res.status(200).send(data[1][0]);
                     console.log(
                         `[${moment().format(
                             dateFormat
@@ -614,9 +714,9 @@ exports.update = (req, res) => {
                             `${id}번`
                         )} 데이터가 성공적으로 수정되었습니다. (IP: ${IP})`
                     );
-                } else {
-                    res.send({
-                        message: `${roomLabel} 테이블의 ${id}번 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다.`,
+                } else if (!name && !startDate && !endDate && !warrantyTime) {
+                    res.status(400).send({
+                        message: `${roomLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
@@ -625,7 +725,20 @@ exports.update = (req, res) => {
                             `${roomLabel} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
-                        )} 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다. (IP: ${IP})`
+                        )} 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${roomLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${roomLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
                     );
                 }
             })
@@ -647,7 +760,7 @@ exports.update = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat

--- a/controllers/room.controller.js
+++ b/controllers/room.controller.js
@@ -251,7 +251,7 @@ exports.findOneWithCategory = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Room.findOne({
             where: { roomID: id },
-            order: [["roomID", asc]],
+            order: [[Category, "categoryID", asc]],
             include: [
                 {
                     model: Category,
@@ -323,7 +323,7 @@ exports.findOneWithPost = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Room.findOne({
             where: { roomID: id },
-            order: [["roomID", asc]],
+            order: [[Post, "postID", asc]],
             include: [
                 {
                     model: Post,
@@ -335,7 +335,7 @@ exports.findOneWithPost = (req, res) => {
                         "description",
                         "createDate",
                     ],
-                    order: [["postID", asc]],
+                    order: [[Photo, "photoID", asc]],
                     include: [
                         {
                             model: Photo,
@@ -407,13 +407,13 @@ exports.findOneWithCategoryAndPost = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Room.findOne({
             where: { roomID: id },
-            order: [["roomID", asc]],
+            order: [[Category, "categoryID", asc]],
             include: [
                 {
                     model: Category,
                     as: "categories",
                     attributes: ["categoryID", "name", "progress"],
-                    order: [["categoryID", asc]],
+                    order: [[Post, "postID", asc]],
                     include: [
                         {
                             model: Post,
@@ -424,7 +424,7 @@ exports.findOneWithCategoryAndPost = (req, res) => {
                                 "description",
                                 "createDate",
                             ],
-                            order: [["postID", asc]],
+                            order: [[Photo, "photoID", asc]],
                             include: [
                                 {
                                     model: Photo,
@@ -498,7 +498,7 @@ exports.findOneWithPostAndCategory = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Room.findOne({
             where: { roomID: id },
-            order: [["roomID", asc]],
+            order: [[Post, "postID", asc]],
             include: [
                 {
                     model: Post,
@@ -509,7 +509,7 @@ exports.findOneWithPostAndCategory = (req, res) => {
                         "description",
                         "createDate",
                     ],
-                    order: [["postID", asc]],
+                    order: [Photo, "photoID", asc],
                     include: [
                         {
                             model: Category,
@@ -520,7 +520,6 @@ exports.findOneWithPostAndCategory = (req, res) => {
                             model: Photo,
                             as: "photos",
                             attributes: ["photoID", "url"],
-                            order: [["photoID", asc]],
                         },
                     ],
                 },
@@ -587,19 +586,17 @@ exports.findOneWithUser = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Room.findOne({
             where: { roomID: id },
-            order: [["roomID", asc]],
+            order: [[UserRoom, "userID", asc]],
             include: [
                 {
                     model: UserRoom,
                     as: "userrooms",
-                    attributes: ["userRoomID"],
-                    order: [["userRoomID", asc]],
+                    attributes: ["userID"],
                     include: [
                         {
                             model: User,
                             as: "user",
-                            attributes: ["userID", "number"],
-                            order: [["userID", asc]],
+                            attributes: ["number"],
                             include: [
                                 {
                                     model: Worker,

--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -89,6 +89,7 @@ exports.findAll = (req, res) => {
                         `${userLabel} + ${workerLabel} 테이블`
                     )}의 모든 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                 );
+                console.log(User.name);
             })
             .catch((err) => {
                 res.status(500).send({
@@ -195,7 +196,7 @@ exports.findOneWithRoom = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         User.findOne({
             where: { userID: id },
-            order: [["userID", asc]],
+            order: [[UserRoom, "roomID", asc]],
             include: [
                 {
                     model: Worker,
@@ -206,7 +207,6 @@ exports.findOneWithRoom = (req, res) => {
                     model: UserRoom,
                     as: "userrooms",
                     attributes: ["roomID"],
-                    order: [["roomID", asc]],
                     include: [
                         {
                             model: Room,

--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -34,7 +34,7 @@ exports.create = (req, res) => {
 
         User.create(user)
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${userLabel} 테이블`
@@ -57,7 +57,7 @@ exports.create = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -83,7 +83,7 @@ exports.findAll = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${userLabel} + ${workerLabel} 테이블`
@@ -106,7 +106,7 @@ exports.findAll = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -133,14 +133,31 @@ exports.findOne = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
-                console.log(
-                    `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${userLabel} + ${workerLabel} 테이블`
-                    )}의 ${chalk.yellow(
-                        `${id}번`
-                    )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
-                );
+                if (data) {
+                    res.status(200).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${userLabel} + ${workerLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${userLabel} + ${workerLabel} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${userLabel} + ${workerLabel} 테이블`
+                        )}에서 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
             })
             .catch((err) => {
                 res.status(500).send({
@@ -160,7 +177,7 @@ exports.findOne = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -207,14 +224,31 @@ exports.findOneWithRoom = (req, res) => {
             ],
         })
             .then((data) => {
-                res.send(data);
-                console.log(
-                    `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${userLabel} + ${workerLabel} + ${userroomLabel} + ${roomLabel} 테이블`
-                    )}의 ${chalk.yellow(
-                        `userID=${id}`
-                    )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
-                );
+                if (data) {
+                    res.status(200).send(data);
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${userLabel} + ${workerLabel} + ${userroomLabel} + ${roomLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `userID=${id}`
+                        )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${userLabel} + ${workerLabel} + ${userroomLabel} + ${roomLabel} 테이블에서 userID=${id}인 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${userLabel} + ${workerLabel} + ${userroomLabel} + ${roomLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `userID=${id}`
+                        )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                    );
+                }
             })
             .catch((err) => {
                 res.status(500).send({
@@ -234,7 +268,7 @@ exports.findOneWithRoom = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -248,6 +282,7 @@ exports.findOneWithRoom = (req, res) => {
 exports.update = (req, res) => {
     const id = req.params.id;
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
+    const number = req.body.number;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         User.update(req.body, {
@@ -256,7 +291,7 @@ exports.update = (req, res) => {
         })
             .then((data) => {
                 if (data[0] == 1) {
-                    res.send(data[1][0]);
+                    res.status(200).send(data[1][0]);
                     console.log(
                         `[${moment().format(
                             dateFormat
@@ -266,9 +301,9 @@ exports.update = (req, res) => {
                             `${id}번`
                         )} 데이터가 성공적으로 수정되었습니다. (IP: ${IP})`
                     );
-                } else {
-                    res.send({
-                        message: `${userLabel} 테이블의 ${id}번 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다.`,
+                } else if (!number) {
+                    res.status(400).send({
+                        message: `${userLabel} 테이블의 ${id}번 데이터의 수정을 시도했지만, request의 body가 비어있어 수정할 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
@@ -277,7 +312,20 @@ exports.update = (req, res) => {
                             `${userLabel} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
-                        )} 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다. (IP: ${IP})`
+                        )} 데이터의 수정을 시도했지만, request의 body가 비어있어 수정할 수 없습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${userLabel} 테이블의 ${id}번 데이터의 수정을 시도했지만, 해당 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${userLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터의 수정을 시도했지만, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
                     );
                 }
             })
@@ -299,7 +347,7 @@ exports.update = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat

--- a/controllers/userroom.controller.js
+++ b/controllers/userroom.controller.js
@@ -46,7 +46,7 @@ exports.create = (req, res) => {
 
         UserRoom.create(userroom)
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${userroomLabel} 테이블`
@@ -69,7 +69,7 @@ exports.create = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -86,7 +86,7 @@ exports.findAll = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         UserRoom.findAll({ order: [["userRoomID", asc]] })
             .then((data) => {
-                res.send(data);
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${userroomLabel} 테이블`
@@ -109,7 +109,7 @@ exports.findAll = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -139,7 +139,7 @@ exports.findOne = (req, res) => {
                         )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                     );
                 } else {
-                    res.status(400).send({
+                    res.status(404).send({
                         message: `${userroomLabel} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
@@ -171,7 +171,7 @@ exports.findOne = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat
@@ -185,6 +185,8 @@ exports.findOne = (req, res) => {
 exports.update = (req, res) => {
     const id = req.params.id;
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
+    const userID = req.body.userID;
+    const roomID = req.body.roomID;
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         UserRoom.update(req.body, {
@@ -193,7 +195,7 @@ exports.update = (req, res) => {
         })
             .then((data) => {
                 if (data[0] == 1) {
-                    res.send(data[1][0]);
+                    res.status(200).send(data[1][0]);
                     console.log(
                         `[${moment().format(
                             dateFormat
@@ -203,9 +205,9 @@ exports.update = (req, res) => {
                             `${id}번`
                         )} 데이터가 성공적으로 수정되었습니다. (IP: ${IP})`
                     );
-                } else {
-                    res.send({
-                        message: `U${userroomLabel} 테이블의 ${id}번 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다.`,
+                } else if (!userID && !roomID) {
+                    res.status(400).send({
+                        message: `U${userroomLabel} 테이블의 ${id}번 데이터의 수정을 시도했지만, request의 body가 비어있어 수정할 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
@@ -214,7 +216,20 @@ exports.update = (req, res) => {
                             `${userroomLabel} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
-                        )} 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없거나, request의 body가 비어있습니다. (IP: ${IP})`
+                        )} 데이터의 수정을 시도했지만, request의 body가 비어있어 수정할 수 없습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${userroomLabel} 테이블의 ${id}번 데이터의 수정을 시도했지만, 해당 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${userroomLabel} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터의 수정을 시도했지만, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
                     );
                 }
             })
@@ -236,7 +251,7 @@ exports.update = (req, res) => {
                 );
             });
     } else {
-        res.status(401).send({ message: "Connection Fail" });
+        res.status(403).send({ message: "Connection Fail" });
         console.log(
             `[${moment().format(
                 dateFormat

--- a/controllers/worker.controller.js
+++ b/controllers/worker.controller.js
@@ -50,7 +50,7 @@ exports.create = (req, res) => {
 
         Worker.create(worker)
             .then((data) => {
-                res.status(200).send();
+                res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
                         `${workerLabel} 테이블`
@@ -231,7 +231,7 @@ exports.update = (req, res) => {
                     );
                 } else if (!userIdentifier && !name && !email) {
                     res.status(400).send({
-                        message: `${workerLabel} 테이블의 ${id}번 데이터를 수정할 수 없습니다. request의 body가 비어있습니다.`,
+                        message: `${workerLabel} 테이블의 ${id}번 데이터의 수정을 시도했지만, request의 body가 비어있어 수정할 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
@@ -240,11 +240,11 @@ exports.update = (req, res) => {
                             `${workerLabel} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
-                        )} 데이터를 수정할 수 없습니다. request의 body가 비어있습니다. (IP: ${IP})`
+                        )} 데이터의 수정을 시도했지만, request의 body가 비어있어 수정할 수 없습니다. (IP: ${IP})`
                     );
                 } else {
                     res.status(404).send({
-                        message: `${workerLabel} 테이블의 ${id}번 데이터를 찾을 수 없습니다.`,
+                        message: `${workerLabel} 테이블의 ${id}번 데이터의 수정을 시도했지만, 해당 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
@@ -253,7 +253,7 @@ exports.update = (req, res) => {
                             `${workerLabel} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
-                        )} 데이터를 수정할 수 없습니다. 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                        )} 데이터의 수정을 시도했지만, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
                     );
                 }
             })


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 병합된 데이터 테이블들을 대상으로 Get 메서드로 데이터를 불러왔을 때, 데이터 순서가 id순으로 정렬되지 않고, 최근 수정 데이터가 맨 뒤로 가는 현상을 발견

## Key Changes 🔥 (주요 구현/변경 사항)
- Sequelize의 병합 테이블 데이터 정렬 방법으로 병합된 데이터 테이블의 데이터 순서로 id 순으로 제대로 정렬

## ToDo 📆 (남은 작업)
- [ ] 텍스트로 하드 코딩 되어있는 테이블 이름들 모델의 기본 어트리뷰트 사용해서 출력하도록 변경

## ScreenShot 📷 (참고 사진)
|수정 전|수정 후|
|:-:|:-:|
|<img src="https://user-images.githubusercontent.com/81027256/216830890-5cc29750-3c4f-4b62-b7d7-73032a08769a.png">|<img src="https://user-images.githubusercontent.com/81027256/216830901-0b04f0b2-9dab-488a-b8d0-c0f1c6907451.png">|

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- Sequelize의 Joined Table order가 상위 테이블에서만 먹는다는 것을 모르고 구현했다가 문제를 발견하여 수정합니다.
- 그렇게 길지 않은 코드라 리뷰가 어렵지는 않을 거에요. (지금 왜인지 rebase를 하지도 않았는데, 전 PR의 내용이 여기에 반영이 되어 라인이 늘어나 있네요. 전 PR 머지 이후에 해결해 보겠습니다.)

## Reference 🔗
- [CHAN_STUDIO - sequelize include 안에 order](https://m.blog.naver.com/kimhecan/222030104760)

## Close Issues 🔒 (닫을 Issue)
- Close #60.
