### PR TITLE
[!HOTFIX] 병합된 데이터 테이블의 데이터 순서 정렬이 제대로 되고 있지 않는 문제

### DIFF
--- a/controllers/category.controller.js
+++ b/controllers/category.controller.js
@@ -14,9 +14,6 @@ const dateFormat = "YYYY-MM-DD HH:mm:ss.SSS";
 const reqHeaderIPField = "X-FORWARDED-FOR";
 const reqHeaderAPIKeyField = "API-Key";
 const asc = "ASC";
-const categoryLabel = "Category";
-const postLabel = "Post";
-const photoLabel = "Photo";
 
 dotenv.config();
 
@@ -31,13 +28,13 @@ exports.create = (req, res) => {
 
         if (!roomID || !name) {
             res.status(400).send({
-                message: `${categoryLabel} 테이블의 필수 정보가 누락 되었습니다!`,
+                message: `${Category.name} 테이블의 필수 정보가 누락 되었습니다!`,
             });
             console.log(
                 `[${moment().format(
                     dateFormat
                 )}] ${badAccessError} ${chalk.yellow(
-                    `${categoryLabel} 테이블`
+                    `${Category.name} 테이블`
                 )}의 필수 데이터를 포함하지 않고 Create를 시도했습니다. (IP: ${IP})`
             );
             return;
@@ -54,20 +51,20 @@ exports.create = (req, res) => {
                 res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${categoryLabel} 테이블`
+                        `${Category.name} 테이블`
                     )}에 새로운 데이터가 성공적으로 추가되었습니다. (IP: ${IP})`
                 );
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `새로운 ${categoryLabel}를 추가하는 중에 문제가 발생했습니다.`,
+                    message: `새로운 ${Category.name}를 추가하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} 새로운 ${chalk.yellow(
-                        categoryLabel
+                        Category.name
                     )}를 추가하는 중에 문제가 발생했습니다. ${chalk.dim(
                         `상세정보: ${err.message}`
                     )} (IP: ${IP})`
@@ -94,20 +91,20 @@ exports.findAll = (req, res) => {
                 res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${categoryLabel} 테이블`
+                        `${Category.name} 테이블`
                     )}의 모든 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                 );
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${categoryLabel} 테이블을 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${Category.name} 테이블을 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${categoryLabel} 테이블`
+                        `${Category.name} 테이블`
                     )}을 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
                         `상세정보: ${err.message}`
                     )} (IP: ${IP})`
@@ -138,20 +135,20 @@ exports.findOne = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${categoryLabel} 테이블`
+                            `${Category.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                     );
                 } else {
                     res.status(404).send({
-                        message: `${categoryLabel} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
+                        message: `${Category.name} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${categoryLabel} 테이블`
+                            `${Category.name} 테이블`
                         )}에서 ${chalk.yellow(
                             `${id}번`
                         )} 데이터를 찾을 수 없습니다. (IP: ${IP})`
@@ -160,14 +157,14 @@ exports.findOne = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${categoryLabel} 테이블의 ${id}번 데이터를 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${Category.name} 테이블의 ${id}번 데이터를 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${categoryLabel} 테이블`
+                        `${Category.name} 테이블`
                     )}의 ${chalk.yellow(
                         `${id}번`
                     )} 데이터를 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
@@ -198,7 +195,6 @@ exports.findOneWithPost = (req, res) => {
             include: [
                 {
                     model: Post,
-                    as: "posts",
                     attributes: [
                         "postID",
                         "userID",
@@ -210,7 +206,6 @@ exports.findOneWithPost = (req, res) => {
                     include: [
                         {
                             model: Photo,
-                            as: "photos",
                             attributes: ["photoID", "url"],
                         },
                     ],
@@ -224,7 +219,7 @@ exports.findOneWithPost = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${categoryLabel} + ${postLabel} + ${photoLabel} 테이블`
+                            `${Category.name} + ${Post.name} + ${Photo.name} 테이블`
                         )}의 ${chalk.yellow(
                             `categoryID=${id}`
                         )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
@@ -235,7 +230,7 @@ exports.findOneWithPost = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${categoryLabel} + ${postLabel} + ${photoLabel} 테이블`
+                            `${Category.name} + ${Post.name} + ${Photo.name} 테이블`
                         )}의 ${chalk.yellow(
                             `categoryID=${id}`
                         )}인 데이터를 찾을 수 없습니다. (IP: ${IP})`
@@ -244,14 +239,14 @@ exports.findOneWithPost = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${categoryLabel} + ${postLabel} + ${photoLabel} 테이블의 categoryID=${id}인 데이터를 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${Category.name} + ${Post.name} + ${Photo.name} 테이블의 categoryID=${id}인 데이터를 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${categoryLabel} + ${postLabel} + ${photoLabel} 테이블`
+                        `${Category.name} + ${Post.name} + ${Photo.name} 테이블`
                     )}의 ${chalk.yellow(
                         `categoryID=${id}`
                     )}인 데이터를 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
@@ -290,33 +285,33 @@ exports.update = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${categoryLabel} 테이블`
+                            `${Category.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터가 성공적으로 수정되었습니다. (IP: ${IP})`
                     );
                 } else if (!roomID && !name && !progress) {
                     res.status(400).send({
-                        message: `${categoryLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다.`,
+                        message: `${Category.name} 테이블의 ${id}번 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${categoryLabel} 테이블`
+                            `${Category.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다. (IP: ${IP})`
                     );
                 } else {
                     res.status(404).send({
-                        message: `${categoryLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없있습니다.`,
+                        message: `${Category.name} 테이블의 ${id}번 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없있습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${categoryLabel} 테이블`
+                            `${Category.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
@@ -325,14 +320,14 @@ exports.update = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${categoryLabel} 테이블의 ${id}번 데이터를 수정하는 중에 문제가 발생했습니다.`,
+                    message: `${Category.name} 테이블의 ${id}번 데이터를 수정하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${categoryLabel} 테이블`
+                        `${Category.name} 테이블`
                     )}의 ${chalk.yellow(
                         `${id}번`
                     )} 데이터를 수정하는 중에 문제가 발생했습니다. (IP: ${IP})`

--- a/controllers/category.controller.js
+++ b/controllers/category.controller.js
@@ -12,7 +12,7 @@ const badAccessError = `🔴${chalk.red("Error:")}`;
 const unknownError = `🟣${purple("Error:")}`;
 const dateFormat = "YYYY-MM-DD HH:mm:ss.SSS";
 const reqHeaderIPField = "X-FORWARDED-FOR";
-const reqHeaderAPIKeyField = "API-Key";
+const reqHeaderAPIKeyField = "x-api-key";
 const asc = "ASC";
 
 dotenv.config();

--- a/controllers/category.controller.js
+++ b/controllers/category.controller.js
@@ -191,7 +191,7 @@ exports.findOneWithPost = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Category.findOne({
             where: { categoryID: id },
-            order: [["categoryID", asc]],
+            order: [[Post, "postID", asc]],
             include: [
                 {
                     model: Post,
@@ -202,7 +202,7 @@ exports.findOneWithPost = (req, res) => {
                         "description",
                         "createDate",
                     ],
-                    order: [["postID", asc]],
+                    order: [[Photo, "photoID", asc]],
                     include: [
                         {
                             model: Photo,

--- a/controllers/photo.controller.js
+++ b/controllers/photo.controller.js
@@ -10,7 +10,7 @@ const badAccessError = `🔴${chalk.red("Error:")}`;
 const unknownError = `🟣${purple("Error:")}`;
 const dateFormat = "YYYY-MM-DD HH:mm:ss.SSS";
 const reqHeaderIPField = "X-FORWARDED-FOR";
-const reqHeaderAPIKeyField = "API-Key";
+const reqHeaderAPIKeyField = "x-api-key";
 const asc = "ASC";
 
 dotenv.config();

--- a/controllers/photo.controller.js
+++ b/controllers/photo.controller.js
@@ -12,7 +12,6 @@ const dateFormat = "YYYY-MM-DD HH:mm:ss.SSS";
 const reqHeaderIPField = "X-FORWARDED-FOR";
 const reqHeaderAPIKeyField = "API-Key";
 const asc = "ASC";
-const photoLabel = "Photo";
 
 dotenv.config();
 
@@ -27,13 +26,13 @@ exports.create = (req, res) => {
 
         if (!postID || !url) {
             res.status(400).send({
-                message: `${photoLabel} 테이블의 필수 정보가 누락 되었습니다!`,
+                message: `${Photo.name} 테이블의 필수 정보가 누락 되었습니다!`,
             });
             console.log(
                 `[${moment().format(
                     dateFormat
                 )}] ${badAccessError} ${chalk.yellow(
-                    `${photoLabel} 테이블`
+                    `${Photo.name} 테이블`
                 )}의 필수 데이터를 포함하지 않고 Create를 시도했습니다. (IP: ${IP})`
             );
             return;
@@ -49,20 +48,20 @@ exports.create = (req, res) => {
                 res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${photoLabel} 테이블`
+                        `${Photo.name} 테이블`
                     )}에 새로운 데이터가 성공적으로 추가되었습니다. (IP: ${IP})`
                 );
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `새로운 ${photoLabel}를 추가하는 중에 문제가 발생했습니다.`,
+                    message: `새로운 ${Photo.name}를 추가하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} 새로운 ${chalk.yellow(
-                        photoLabel
+                        Photo.name
                     )}를 추가하는 중에 문제가 발생했습니다. ${chalk.dim(
                         `상세정보: ${err.message}`
                     )} (IP: ${IP})`
@@ -89,20 +88,20 @@ exports.findAll = (req, res) => {
                 res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${photoLabel} 테이블`
+                        `${Photo.name} 테이블`
                     )}의 모든 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                 );
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${photoLabel} 테이블을 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${Photo.name} 테이블을 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${photoLabel} 테이블`
+                        `${Photo.name} 테이블`
                     )}을 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
                         `상세정보: ${err.message}`
                     )} (IP: ${IP})`
@@ -133,20 +132,20 @@ exports.findOne = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${photoLabel} 테이블`
+                            `${Photo.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                     );
                 } else {
                     res.status(404).send({
-                        message: `${photoLabel} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
+                        message: `${Photo.name} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${photoLabel} 테이블`
+                            `${Photo.name} 테이블`
                         )}에서 ${chalk.yellow(
                             `${id}번`
                         )} 데이터를 찾을 수 없습니다. (IP: ${IP})`
@@ -155,14 +154,14 @@ exports.findOne = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${photoLabel} 테이블의 ${id}번 데이터를 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${Photo.name} 테이블의 ${id}번 데이터를 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${photoLabel} 테이블`
+                        `${Photo.name} 테이블`
                     )}의 ${chalk.yellow(
                         `${id}번`
                     )} 데이터를 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
@@ -200,33 +199,33 @@ exports.update = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${photoLabel} 테이블`
+                            `${Photo.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터가 성공적으로 수정되었습니다. (IP: ${IP})`
                     );
                 } else if (!postID && !url) {
                     res.status(400).send({
-                        message: `${photoLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다.`,
+                        message: `${Photo.name} 테이블의 ${id}번 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${photoLabel} 테이블`
+                            `${Photo.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다. (IP: ${IP})`
                     );
                 } else {
                     res.status(404).send({
-                        message: `${photoLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다.`,
+                        message: `${Photo.name} 테이블의 ${id}번 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${photoLabel} 테이블`
+                            `${Photo.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
@@ -235,14 +234,14 @@ exports.update = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${photoLabel} 테이블의 ${id}번 데이터를 수정하는 중에 문제가 발생했습니다.`,
+                    message: `${Photo.name} 테이블의 ${id}번 데이터를 수정하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${photoLabel} 테이블`
+                        `${Photo.name} 테이블`
                     )}의 ${chalk.yellow(
                         `${id}번`
                     )} 데이터를 수정하는 중에 문제가 발생했습니다. ${chalk.dim(

--- a/controllers/post.controller.js
+++ b/controllers/post.controller.js
@@ -13,7 +13,7 @@ const badAccessError = `🔴${chalk.red("Error:")}`;
 const unknownError = `🟣${purple("Error:")}`;
 const dateFormat = "YYYY-MM-DD HH:mm:ss.SSS";
 const reqHeaderIPField = "X-FORWARDED-FOR";
-const reqHeaderAPIKeyField = "API-Key";
+const reqHeaderAPIKeyField = "x-api-key";
 const asc = "ASC";
 
 dotenv.config();

--- a/controllers/post.controller.js
+++ b/controllers/post.controller.js
@@ -90,7 +90,10 @@ exports.findAll = (req, res) => {
 
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Post.findAll({
-            order: [["postID", asc]],
+            order: [
+                ["postID", asc],
+                [Photo, "photoID", asc],
+            ],
             include: [
                 {
                     model: Photo,
@@ -140,6 +143,7 @@ exports.findOne = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Post.findOne({
             where: { postID: id },
+            order: [[Photo, "photoID", asc]],
             include: [
                 {
                     model: Photo,
@@ -215,12 +219,14 @@ exports.findOneWithUser = (req, res) => {
                 "description",
                 "createDate",
             ],
-            order: [["postID", asc]],
+            order: [
+                [User, "userID", asc],
+                [Photo, "photoID", asc],
+            ],
             include: [
                 {
                     model: User,
                     attributes: ["userID", "number"],
-                    order: [["userID", asc]],
                     include: [
                         {
                             model: Worker,

--- a/controllers/post.controller.js
+++ b/controllers/post.controller.js
@@ -15,10 +15,6 @@ const dateFormat = "YYYY-MM-DD HH:mm:ss.SSS";
 const reqHeaderIPField = "X-FORWARDED-FOR";
 const reqHeaderAPIKeyField = "API-Key";
 const asc = "ASC";
-const userLabel = "User";
-const workerLabel = "Worker";
-const postLabel = "Post";
-const photoLabel = "Photo";
 
 dotenv.config();
 
@@ -34,13 +30,13 @@ exports.create = (req, res) => {
 
         if (!roomID || !userID || !categoryID) {
             res.status(400).send({
-                message: `${postLabel} 테이블의 필수 정보가 누락 되었습니다.`,
+                message: `${Post.name} 테이블의 필수 정보가 누락 되었습니다.`,
             });
             console.log(
                 `[${moment().format(
                     dateFormat
                 )}] ${badAccessError} ${chalk.yellow(
-                    `${postLabel} 테이블`
+                    `${Post.name} 테이블`
                 )}의 필수 데이터를 포함하지 않고 Create를 시도했습니다. (IP: ${IP})`
             );
             return;
@@ -58,20 +54,20 @@ exports.create = (req, res) => {
                 res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${postLabel} 테이블`
+                        `${Post.name} 테이블`
                     )}에 새로운 데이터가 성공적으로 추가되었습니다. (IP: ${IP})`
                 );
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `새로운 ${postLabel}를 추가하는 중에 문제가 발생했습니다.`,
+                    message: `새로운 ${Post.name}를 추가하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} 새로운 ${chalk.yellow(
-                        postLabel
+                        Post.name
                     )}를 추가하는 중에 문제가 발생했습니다. ${chalk.dim(
                         `상세정보: ${err.message}`
                     )} (IP: ${IP})`
@@ -98,7 +94,6 @@ exports.findAll = (req, res) => {
             include: [
                 {
                     model: Photo,
-                    as: "photos",
                     attributes: ["photoID", "url"],
                 },
             ],
@@ -107,20 +102,20 @@ exports.findAll = (req, res) => {
                 res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${postLabel} + ${photoLabel} 테이블`
+                        `${Post.name} + ${Photo.name} 테이블`
                     )}의 모든 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                 );
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${postLabel} + ${photoLabel} 테이블을 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${Post.name} + ${Photo.name} 테이블을 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${postLabel} + ${photoLabel} 테이블`
+                        `${Post.name} + ${Photo.name} 테이블`
                     )}을 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
                         `상세정보: ${err.message}`
                     )} (IP: ${IP})`
@@ -148,7 +143,6 @@ exports.findOne = (req, res) => {
             include: [
                 {
                     model: Photo,
-                    as: "photos",
                     attributes: ["photoID", "url"],
                 },
             ],
@@ -160,7 +154,7 @@ exports.findOne = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${postLabel} + ${photoLabel} 테이블`
+                            `${Post.name} + ${Photo.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
@@ -171,7 +165,7 @@ exports.findOne = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${postLabel} + ${photoLabel} 테이블`
+                            `${Post.name} + ${Photo.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터를 찾을 수 없습니다. (IP: ${IP})`
@@ -180,14 +174,14 @@ exports.findOne = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${postLabel} + ${photoLabel} 테이블의 ${id}번 데이터를 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${Post.name} + ${Photo.name} 테이블의 ${id}번 데이터를 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${postLabel} + ${photoLabel} 테이블`
+                        `${Post.name} + ${Photo.name} 테이블`
                     )}의 ${chalk.yellow(
                         `${id}번`
                     )} 데이터를 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
@@ -225,7 +219,6 @@ exports.findOneWithUser = (req, res) => {
             include: [
                 {
                     model: User,
-                    as: "user",
                     attributes: ["userID", "number"],
                     order: [["userID", asc]],
                     include: [
@@ -238,7 +231,6 @@ exports.findOneWithUser = (req, res) => {
                 },
                 {
                     model: Photo,
-                    as: "photos",
                     attributes: ["photoID", "url"],
                 },
             ],
@@ -250,7 +242,7 @@ exports.findOneWithUser = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${postLabel} + ${userLabel} + ${workerLabel} + ${photoLabel} 테이블`
+                            `${Post.name} + ${User.name} + ${Worker.name} + ${Photo.name} 테이블`
                         )}의 ${chalk.yellow(
                             `postID=${id}`
                         )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
@@ -261,7 +253,7 @@ exports.findOneWithUser = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${postLabel} + ${userLabel} + ${workerLabel} + ${photoLabel} 테이블`
+                            `${Post.name} + ${User.name} + ${Worker.name} + ${Photo.name} 테이블`
                         )}의 ${chalk.yellow(
                             `postID=${id}`
                         )}인 데이터를 찾을 수 없습니다. (IP: ${IP})`
@@ -270,14 +262,14 @@ exports.findOneWithUser = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${postLabel} + ${userLabel} + ${workerLabel} + ${photoLabel} 테이블의 postID=${id}인 데이터를 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${Post.name} + ${User.name} + ${Worker.name} + ${Photo.name} 테이블의 postID=${id}인 데이터를 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${postLabel} + ${userLabel} + ${workerLabel} + ${photoLabel} 테이블`
+                        `${Post.name} + ${User.name} + ${Worker.name} + ${Photo.name} 테이블`
                     )}의 ${chalk.yellow(
                         `postID=${id}`
                     )}인 데이터를 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
@@ -309,13 +301,13 @@ exports.update = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         if (createDate) {
             res.status(400).send({
-                message: `${postLabel} 테이블의 ${id}번 데이터의 createDate를 ${createDate}로 변경할 수 없습니다.`,
+                message: `${Post.name} 테이블의 ${id}번 데이터의 createDate를 ${createDate}로 변경할 수 없습니다.`,
             });
             console.log(
                 `[${moment().format(
                     dateFormat
                 )}] ${badAccessError} ${chalk.yellow(
-                    `${postLabel} 테이블`
+                    `${Post.name} 테이블`
                 )}의 ${chalk.yellow(
                     `${id}번`
                 )} 데이터의 createDate를 ${chalk.yellow(
@@ -336,33 +328,33 @@ exports.update = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${postLabel} 테이블`
+                            `${Post.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터가 성공적으로 수정되었습니다. (IP: ${IP})`
                     );
                 } else if (!roomID && !userID && !categoryID && !description) {
                     res.status(400).send({
-                        message: `${postLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다.`,
+                        message: `${Post.name} 테이블의 ${id}번 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${postLabel} 테이블`
+                            `${Post.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다. (IP: ${IP})`
                     );
                 } else {
                     res.status(404).send({
-                        message: `${postLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다.`,
+                        message: `${Post.name} 테이블의 ${id}번 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${postLabel} 테이블`
+                            `${Post.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
@@ -371,14 +363,14 @@ exports.update = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${postLabel} 테이블의 ${id}번 데이터를 수정하는 중에 문제가 발생했습니다.`,
+                    message: `${Post.name} 테이블의 ${id}번 데이터를 수정하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${postLabel} 테이블`
+                        `${Post.name} 테이블`
                     )}의 ${chalk.yellow(
                         `${id}번`
                     )} 데이터를 수정하는 중에 문제가 발생했습니다. ${chalk.dim(

--- a/controllers/room.controller.js
+++ b/controllers/room.controller.js
@@ -18,13 +18,6 @@ const unknownError = `🟣${purple("Error:")}`;
 const reqHeaderIPField = "X-FORWARDED-FOR";
 const reqHeaderAPIKeyField = "API-Key";
 const asc = "ASC";
-const userLabel = "User";
-const workerLabel = "Worker";
-const roomLabel = "Room";
-const userroomLabel = "User-Room";
-const categoryLabel = "Category";
-const postLabel = "Post";
-const photoLabel = "Photo";
 
 dotenv.config();
 
@@ -42,7 +35,7 @@ exports.create = (req, res) => {
                 `[${moment().format(
                     dateFormat
                 )}] ${badAccessError} ${chalk.yellow(
-                    `${roomLabel} 테이블`
+                    `${Room.name} 테이블`
                 )}의 필수 데이터 name을 포함하지 않고 Create를 시도했습니다. (IP: ${IP})`
             );
             return;
@@ -111,20 +104,20 @@ exports.create = (req, res) => {
                 res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${roomLabel} 테이블`
+                        `${Room.name} 테이블`
                     )}에 새로운 데이터가 성공적으로 추가되었습니다. (IP: ${IP})`
                 );
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `새로운 ${roomLabel}을 추가하는 중에 문제가 발생했습니다.`,
+                    message: `새로운 ${Room.name}을 추가하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${badAccessError} 새로운 ${chalk.yellow(
-                        roomLabel
+                        Room.name
                     )}을 추가하는 중에 문제가 발생했습니다. ${chalk.dim(
                         "상세정보: " + err.message
                     )} (IP: ${IP})`
@@ -151,20 +144,20 @@ exports.findAll = (req, res) => {
                 res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${roomLabel} 테이블`
+                        `${Room.name} 테이블`
                     )}의 모든 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                 );
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${roomLabel} 테이블을 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${Room.name} 테이블을 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${roomLabel} 테이블`
+                        `${Room.name} 테이블`
                     )}을 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
                         "상세정보: " + err.message
                     )} (IP: ${IP})`
@@ -195,20 +188,20 @@ exports.findOne = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${roomLabel} 테이블`
+                            `${Room.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                     );
                 } else {
                     res.status(404).send({
-                        message: `${roomLabel} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
+                        message: `${Room.name} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${roomLabel} 테이블`
+                            `${Room.name} 테이블`
                         )}에서 ${chalk.yellow(
                             `${id}번`
                         )} 데이터를 찾을 수 없습니다. (IP: ${IP})`
@@ -217,14 +210,14 @@ exports.findOne = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${roomLabel} 테이블의 ${id}번 데이터를 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${Room.name} 테이블의 ${id}번 데이터를 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${roomLabel} 테이블`
+                        `${Room.name} 테이블`
                     )}의 ${chalk.yellow(
                         `${id}번`
                     )} 데이터를 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
@@ -255,7 +248,6 @@ exports.findOneWithCategory = (req, res) => {
             include: [
                 {
                     model: Category,
-                    as: "categories",
                     attributes: ["categoryID", "name", "progress"],
                 },
             ],
@@ -267,20 +259,20 @@ exports.findOneWithCategory = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${roomLabel} + ${categoryLabel} 테이블`
+                            `${Room.name} + ${Category.name} 테이블`
                         )}의 ${chalk.yellow(
                             `roomID=${id}`
                         )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                     );
                 } else {
                     res.status(404).send({
-                        message: `${roomLabel} + ${categoryLabel} 테이블에서 roomID=${id}인 데이터를 찾을 수 없습니다.`,
+                        message: `${Room.name} + ${Category.name} 테이블에서 roomID=${id}인 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${roomLabel} + ${categoryLabel} 테이블`
+                            `${Room.name} + ${Category.name} 테이블`
                         )}에서 ${chalk.yellow(
                             `roomID=${id}`
                         )}인 데이터를 찾을 수 없습니다. (IP: ${IP})`
@@ -289,14 +281,14 @@ exports.findOneWithCategory = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${roomLabel} + ${categoryLabel} 테이블의 roomID=${id}인 데이터를 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${Room.name} + ${Category.name} 테이블의 roomID=${id}인 데이터를 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${roomLabel} + ${categoryLabel} 테이블`
+                        `${Room.name} + ${Category.name} 테이블`
                     )}의 ${chalk.yellow(
                         `roomID=${id}`
                     )}인 데이터를 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
@@ -327,7 +319,6 @@ exports.findOneWithPost = (req, res) => {
             include: [
                 {
                     model: Post,
-                    as: "posts",
                     attributes: [
                         "postID",
                         "userID",
@@ -339,7 +330,6 @@ exports.findOneWithPost = (req, res) => {
                     include: [
                         {
                             model: Photo,
-                            as: "photos",
                             attributes: ["photoID", "url"],
                         },
                     ],
@@ -353,7 +343,7 @@ exports.findOneWithPost = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${roomLabel} + ${postLabel} + ${photoLabel} 테이블`
+                            `${Room.name} + ${Post.name} + ${Photo.name} 테이블`
                         )}의 ${chalk.yellow(
                             `roomID=${id}`
                         )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
@@ -364,7 +354,7 @@ exports.findOneWithPost = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${roomLabel} + ${postLabel} + ${photoLabel} 테이블`
+                            `${Room.name} + ${Post.name} + ${Photo.name} 테이블`
                         )}의 ${chalk.yellow(
                             `roomID=${id}`
                         )}인 데이터를 찾을 수 없습니다. (IP: ${IP})`
@@ -373,14 +363,14 @@ exports.findOneWithPost = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${roomLabel} + ${postLabel} + ${photoLabel} 테이블의 roomID=${id}인 데이터를 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${Room.name} + ${Post.name} + ${Photo.name} 테이블의 roomID=${id}인 데이터를 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${roomLabel} + ${postLabel} + ${photoLabel} 테이블`
+                        `${Room.name} + ${Post.name} + ${Photo.name} 테이블`
                     )}의 ${chalk.yellow(
                         `roomID=${id}`
                     )}인 데이터를 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
@@ -411,13 +401,11 @@ exports.findOneWithCategoryAndPost = (req, res) => {
             include: [
                 {
                     model: Category,
-                    as: "categories",
                     attributes: ["categoryID", "name", "progress"],
                     order: [["categoryID", asc]],
                     include: [
                         {
                             model: Post,
-                            as: "posts",
                             attributes: [
                                 "postID",
                                 "userID",
@@ -428,7 +416,6 @@ exports.findOneWithCategoryAndPost = (req, res) => {
                             include: [
                                 {
                                     model: Photo,
-                                    as: "photos",
                                     attributes: ["photoID", "url"],
                                 },
                             ],
@@ -444,7 +431,7 @@ exports.findOneWithCategoryAndPost = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${roomLabel} + ${categoryLabel} + ${postLabel} + ${photoLabel} 테이블`
+                            `${Room.name} + ${Category.name} + ${Post.name} + ${Photo.name} 테이블`
                         )}의 ${chalk.yellow(
                             `roomID=${id}`
                         )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
@@ -455,7 +442,7 @@ exports.findOneWithCategoryAndPost = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${roomLabel} + ${categoryLabel} + ${postLabel} + ${photoLabel} 테이블`
+                            `${Room.name} + ${Category.name} + ${Post.name} + ${Photo.name} 테이블`
                         )}의 ${chalk.yellow(
                             `roomID=${id}`
                         )}인 데이터를 찾을 수 없습니다. (IP: ${IP})`
@@ -464,14 +451,14 @@ exports.findOneWithCategoryAndPost = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${roomLabel} + ${categoryLabel} + ${postLabel} + ${photoLabel} 테이블의 roomID=${id}인 데이터를 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${Room.name} + ${Category.name} + ${Post.name} + ${Photo.name} 테이블의 roomID=${id}인 데이터를 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${roomLabel} + ${categoryLabel} + ${postLabel} + ${photoLabel} 테이블`
+                        `${Room.name} + ${Category.name} + ${Post.name} + ${Photo.name} 테이블`
                     )}의 ${chalk.yellow(
                         `roomID=${id}`
                     )}인 데이터를 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
@@ -502,7 +489,6 @@ exports.findOneWithPostAndCategory = (req, res) => {
             include: [
                 {
                     model: Post,
-                    as: "posts",
                     attributes: [
                         "postID",
                         "userID",
@@ -513,12 +499,10 @@ exports.findOneWithPostAndCategory = (req, res) => {
                     include: [
                         {
                             model: Category,
-                            as: "category",
                             attributes: ["categoryID", "name"],
                         },
                         {
                             model: Photo,
-                            as: "photos",
                             attributes: ["photoID", "url"],
                             order: [["photoID", asc]],
                         },
@@ -533,7 +517,7 @@ exports.findOneWithPostAndCategory = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${roomLabel} + ${postLabel} + ${categoryLabel} + ${photoLabel} 테이블`
+                            `${Room.name} + ${Post.name} + ${Category.name} + ${Photo.name} 테이블`
                         )}의 ${chalk.yellow(
                             `roomID=${id}`
                         )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
@@ -544,7 +528,7 @@ exports.findOneWithPostAndCategory = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${roomLabel} + ${postLabel} + ${categoryLabel} + ${photoLabel} 테이블`
+                            `${Room.name} + ${Post.name} + ${Category.name} + ${Photo.name} 테이블`
                         )}의 ${chalk.yellow(
                             `roomID=${id}`
                         )}인 데이터를 찾을 수 없습니다. (IP: ${IP})`
@@ -553,14 +537,14 @@ exports.findOneWithPostAndCategory = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${roomLabel} + ${postLabel} + ${categoryLabel} + ${photoLabel} 테이블의 roomID=${id}인 데이터를 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${Room.name} + ${Post.name} + ${Category.name} + ${Photo.name} 테이블의 roomID=${id}인 데이터를 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${roomLabel} + ${postLabel} + ${categoryLabel} + ${photoLabel} 테이블`
+                        `${Room.name} + ${Post.name} + ${Category.name} + ${Photo.name} 테이블`
                     )}의 ${chalk.yellow(
                         `roomID=${id}`
                     )}인 데이터를 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
@@ -591,19 +575,16 @@ exports.findOneWithUser = (req, res) => {
             include: [
                 {
                     model: UserRoom,
-                    as: "userrooms",
                     attributes: ["userRoomID"],
                     order: [["userRoomID", asc]],
                     include: [
                         {
                             model: User,
-                            as: "user",
                             attributes: ["userID", "number"],
                             order: [["userID", asc]],
                             include: [
                                 {
                                     model: Worker,
-                                    as: "worker",
                                     attributes: [
                                         "userIdentifier",
                                         "name",
@@ -623,7 +604,7 @@ exports.findOneWithUser = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${roomLabel} + ${userroomLabel} + ${userLabel} + ${workerLabel} 테이블`
+                            `${Room.name} + ${UserRoom.name} + ${User.name} + ${Worker.name} 테이블`
                         )}의 ${chalk.yellow(
                             `roomID=${id}`
                         )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
@@ -634,7 +615,7 @@ exports.findOneWithUser = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${roomLabel} + ${userroomLabel} + ${userLabel} + ${workerLabel} 테이블`
+                            `${Room.name} + ${UserRoom.name} + ${User.name} + ${Worker.name} 테이블`
                         )}의 ${chalk.yellow(
                             `roomID=${id}`
                         )}인 데이터를 찾을 수 없습니다. (IP: ${IP})`
@@ -643,14 +624,14 @@ exports.findOneWithUser = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${roomLabel} + ${userroomLabel} + ${userLabel} + ${workerLabel} 테이블의 roomID=${id}인 데이터를 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${Room.name} + ${UserRoom.name} + ${User.name} + ${Worker.name} 테이블의 roomID=${id}인 데이터를 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${roomLabel} + ${userroomLabel} + ${userLabel} + ${workerLabel} 테이블`
+                        `${Room.name} + ${UserRoom.name} + ${User.name} + ${Worker.name} 테이블`
                     )}의 ${chalk.yellow(
                         `roomID=${id}`
                     )}인 데이터를 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
@@ -682,13 +663,13 @@ exports.update = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         if (inviteCode) {
             res.status(400).send({
-                message: `${roomLabel} 테이블의 ${id}번 데이터의 inviteCode를 ${inviteCode}로 변경할 수 없습니다.`,
+                message: `${Room.name} 테이블의 ${id}번 데이터의 inviteCode를 ${inviteCode}로 변경할 수 없습니다.`,
             });
             console.log(
                 `[${moment().format(
                     dateFormat
                 )}] ${badAccessError} ${chalk.yellow(
-                    `${roomLabel} 테이블`
+                    `${Room.name} 테이블`
                 )}의 ${chalk.yellow(
                     `${id}번`
                 )} 데이터의 inviteCode를 ${chalk.yellow(
@@ -709,33 +690,33 @@ exports.update = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${roomLabel} 테이블`
+                            `${Room.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터가 성공적으로 수정되었습니다. (IP: ${IP})`
                     );
                 } else if (!name && !startDate && !endDate && !warrantyTime) {
                     res.status(400).send({
-                        message: `${roomLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다.`,
+                        message: `${Room.name} 테이블의 ${id}번 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${roomLabel} 테이블`
+                            `${Room.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터의 수정을 시도했으나, request의 body가 비어있어 수정할 수 없습니다. (IP: ${IP})`
                     );
                 } else {
                     res.status(404).send({
-                        message: `${roomLabel} 테이블의 ${id}번 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다.`,
+                        message: `${Room.name} 테이블의 ${id}번 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${roomLabel} 테이블`
+                            `${Room.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터의 수정을 시도했으나, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
@@ -744,14 +725,14 @@ exports.update = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${roomLabel} 테이블의 ${id}번 데이터를 수정하는 중에 문제가 발생했습니다.`,
+                    message: `${Room.name} 테이블의 ${id}번 데이터를 수정하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${roomLabel} 테이블`
+                        `${Room.name} 테이블`
                     )}의 ${chalk.yellow(
                         `${id}번`
                     )} 데이터를 수정하는 중에 문제가 발생했습니다. ${chalk.dim(

--- a/controllers/room.controller.js
+++ b/controllers/room.controller.js
@@ -16,7 +16,7 @@ const success = `🟢${chalk.green("Success:")}`;
 const badAccessError = `🔴${chalk.red("Error:")}`;
 const unknownError = `🟣${purple("Error:")}`;
 const reqHeaderIPField = "X-FORWARDED-FOR";
-const reqHeaderAPIKeyField = "API-Key";
+const reqHeaderAPIKeyField = "x-api-key";
 const asc = "ASC";
 
 dotenv.config();

--- a/controllers/room.controller.js
+++ b/controllers/room.controller.js
@@ -244,7 +244,7 @@ exports.findOneWithCategory = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Room.findOne({
             where: { roomID: id },
-            order: [["roomID", asc]],
+            order: [[Category, "categoryID", asc]],
             include: [
                 {
                     model: Category,
@@ -315,7 +315,7 @@ exports.findOneWithPost = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Room.findOne({
             where: { roomID: id },
-            order: [["roomID", asc]],
+            order: [[Post, "postID", asc]],
             include: [
                 {
                     model: Post,
@@ -326,7 +326,7 @@ exports.findOneWithPost = (req, res) => {
                         "description",
                         "createDate",
                     ],
-                    order: [["postID", asc]],
+                    order: [[Photo, "photoID", asc]],
                     include: [
                         {
                             model: Photo,
@@ -397,12 +397,12 @@ exports.findOneWithCategoryAndPost = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Room.findOne({
             where: { roomID: id },
-            order: [["roomID", asc]],
+            order: [[Category, "categoryID", asc]],
             include: [
                 {
                     model: Category,
                     attributes: ["categoryID", "name", "progress"],
-                    order: [["categoryID", asc]],
+                    order: [[Post, "postID", asc]],
                     include: [
                         {
                             model: Post,
@@ -412,7 +412,7 @@ exports.findOneWithCategoryAndPost = (req, res) => {
                                 "description",
                                 "createDate",
                             ],
-                            order: [["postID", asc]],
+                            order: [[Photo, "photoID", asc]],
                             include: [
                                 {
                                     model: Photo,
@@ -485,7 +485,7 @@ exports.findOneWithPostAndCategory = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Room.findOne({
             where: { roomID: id },
-            order: [["roomID", asc]],
+            order: [[Post, "postID", asc]],
             include: [
                 {
                     model: Post,
@@ -495,7 +495,7 @@ exports.findOneWithPostAndCategory = (req, res) => {
                         "description",
                         "createDate",
                     ],
-                    order: [["postID", asc]],
+                    order: [[Photo, "photoID", asc]],
                     include: [
                         {
                             model: Category,
@@ -504,7 +504,6 @@ exports.findOneWithPostAndCategory = (req, res) => {
                         {
                             model: Photo,
                             attributes: ["photoID", "url"],
-                            order: [["photoID", asc]],
                         },
                     ],
                 },
@@ -571,17 +570,15 @@ exports.findOneWithUser = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Room.findOne({
             where: { roomID: id },
-            order: [["roomID", asc]],
+            order: [[UserRoom, "userID", asc]],
             include: [
                 {
                     model: UserRoom,
-                    attributes: ["userRoomID"],
-                    order: [["userRoomID", asc]],
+                    attributes: ["userID"],
                     include: [
                         {
                             model: User,
-                            attributes: ["userID", "number"],
-                            order: [["userID", asc]],
+                            attributes: ["number"],
                             include: [
                                 {
                                     model: Worker,

--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -15,10 +15,6 @@ const unknownError = `🟣${purple("Error:")}`;
 const reqHeaderIPField = "X-FORWARDED-FOR";
 const reqHeaderAPIKeyField = "API-Key";
 const asc = "ASC";
-const userLabel = "User";
-const workerLabel = "Worker";
-const roomLabel = "Room";
-const userroomLabel = "User-Room";
 
 dotenv.config();
 
@@ -37,20 +33,20 @@ exports.create = (req, res) => {
                 res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${userLabel} 테이블`
+                        `${User.name} 테이블`
                     )}에 새로운 데이터가 성공적으로 추가되었습니다. (IP: ${IP})`
                 );
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `새로운 ${userLabel}를 추가하는 중에 문제가 발생했습니다.`,
+                    message: `새로운 ${User.name}를 추가하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} 새로운 ${chalk.yellow(
-                        userLabel
+                        User.name
                     )}를 추가하는 중에 문제가 발생했습니다. ${chalk.dim(
                         `상세정보: ${err.message}`
                     )} (IP: ${IP})`
@@ -77,7 +73,6 @@ exports.findAll = (req, res) => {
             include: [
                 {
                     model: Worker,
-                    as: "worker",
                     attributes: ["userIdentifier", "name", "email"],
                 },
             ],
@@ -86,20 +81,20 @@ exports.findAll = (req, res) => {
                 res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${userLabel} + ${workerLabel} 테이블`
+                        `${User.name} + ${Worker.name} 테이블`
                     )}의 모든 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                 );
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${userLabel} + ${workerLabel} 테이블을 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${User.name} + ${Worker.name} 테이블을 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${userLabel} + ${workerLabel} 테이블`
+                        `${User.name} + ${Worker.name} 테이블`
                     )}을 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
                         `상세정보: ${err.message}`
                     )} (IP: ${IP})`
@@ -127,7 +122,6 @@ exports.findOne = (req, res) => {
             include: [
                 {
                     model: Worker,
-                    as: "worker",
                     attributes: ["userIdentifier", "name", "email"],
                 },
             ],
@@ -139,20 +133,20 @@ exports.findOne = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${userLabel} + ${workerLabel} 테이블`
+                            `${User.name} + ${Worker.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                     );
                 } else {
                     res.status(404).send({
-                        message: `${userLabel} + ${workerLabel} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
+                        message: `${User.name} + ${Worker.name} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${userLabel} + ${workerLabel} 테이블`
+                            `${User.name} + ${Worker.name} 테이블`
                         )}에서 ${chalk.yellow(
                             `${id}번`
                         )} 데이터를 찾을 수 없습니다. (IP: ${IP})`
@@ -161,14 +155,14 @@ exports.findOne = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${userLabel} + ${workerLabel} 테이블의 ${id}번 데이터를 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${User.name} + ${Worker.name} 테이블의 ${id}번 데이터를 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${userLabel} + ${workerLabel} 테이블`
+                        `${User.name} + ${Worker.name} 테이블`
                     )}의 ${chalk.yellow(
                         `${id}번`
                     )} 데이터를 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
@@ -199,18 +193,15 @@ exports.findOneWithRoom = (req, res) => {
             include: [
                 {
                     model: Worker,
-                    as: "worker",
                     attributes: ["userIdentifier", "name", "email"],
                 },
                 {
                     model: UserRoom,
-                    as: "userrooms",
                     attributes: ["roomID"],
                     order: [["roomID", asc]],
                     include: [
                         {
                             model: Room,
-                            as: "room",
                             attributes: [
                                 "name",
                                 "startDate",
@@ -230,20 +221,20 @@ exports.findOneWithRoom = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${userLabel} + ${workerLabel} + ${userroomLabel} + ${roomLabel} 테이블`
+                            `${User.name} + ${Worker.name} + ${UserRoom.name} + ${Room.name} 테이블`
                         )}의 ${chalk.yellow(
                             `userID=${id}`
                         )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                     );
                 } else {
                     res.status(404).send({
-                        message: `${userLabel} + ${workerLabel} + ${userroomLabel} + ${roomLabel} 테이블에서 userID=${id}인 데이터를 찾을 수 없습니다.`,
+                        message: `${User.name} + ${Worker.name} + ${UserRoom.name} + ${Room.name} 테이블에서 userID=${id}인 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${userLabel} + ${workerLabel} + ${userroomLabel} + ${roomLabel} 테이블`
+                            `${User.name} + ${Worker.name} + ${UserRoom.name} + ${Room.name} 테이블`
                         )}의 ${chalk.yellow(
                             `userID=${id}`
                         )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
@@ -252,14 +243,14 @@ exports.findOneWithRoom = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${userLabel} + ${workerLabel} + ${userroomLabel} + ${roomLabel} 테이블의 userID=${id}인 데이터를 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${User.name} + ${Worker.name} + ${UserRoom.name} + ${Room.name} 테이블의 userID=${id}인 데이터를 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${userLabel} + ${workerLabel} + ${userroomLabel} + ${roomLabel} 테이블`
+                        `${User.name} + ${Worker.name} + ${UserRoom.name} + ${Room.name} 테이블`
                     )}의 ${chalk.yellow(
                         `userID=${id}`
                     )}인 데이터를 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
@@ -296,33 +287,33 @@ exports.update = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${userLabel} 테이블`
+                            `${User.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터가 성공적으로 수정되었습니다. (IP: ${IP})`
                     );
                 } else if (!number) {
                     res.status(400).send({
-                        message: `${userLabel} 테이블의 ${id}번 데이터의 수정을 시도했지만, request의 body가 비어있어 수정할 수 없습니다.`,
+                        message: `${User.name} 테이블의 ${id}번 데이터의 수정을 시도했지만, request의 body가 비어있어 수정할 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${userLabel} 테이블`
+                            `${User.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터의 수정을 시도했지만, request의 body가 비어있어 수정할 수 없습니다. (IP: ${IP})`
                     );
                 } else {
                     res.status(404).send({
-                        message: `${userLabel} 테이블의 ${id}번 데이터의 수정을 시도했지만, 해당 데이터를 찾을 수 없습니다.`,
+                        message: `${User.name} 테이블의 ${id}번 데이터의 수정을 시도했지만, 해당 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${userLabel} 테이블`
+                            `${User.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터의 수정을 시도했지만, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
@@ -331,14 +322,14 @@ exports.update = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${userLabel} 테이블의 ${id}번 데이터를 수정하는 중에 문제가 발생했습니다.`,
+                    message: `${User.name} 테이블의 ${id}번 데이터를 수정하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${userLabel} 테이블`
+                        `${User.name} 테이블`
                     )}의 ${chalk.yellow(
                         `${id}번`
                     )} 데이터를 수정하는 중에 문제가 발생했습니다. ${chalk.dim(

--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -189,7 +189,7 @@ exports.findOneWithRoom = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         User.findOne({
             where: { userID: id },
-            order: [["userID", asc]],
+            order: [[UserRoom, "roomID", asc]],
             include: [
                 {
                     model: Worker,
@@ -198,7 +198,6 @@ exports.findOneWithRoom = (req, res) => {
                 {
                     model: UserRoom,
                     attributes: ["roomID"],
-                    order: [["roomID", asc]],
                     include: [
                         {
                             model: Room,

--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -13,7 +13,7 @@ const success = `🟢${chalk.green("Success:")}`;
 const badAccessError = `🔴${chalk.red("Error:")}`;
 const unknownError = `🟣${purple("Error:")}`;
 const reqHeaderIPField = "X-FORWARDED-FOR";
-const reqHeaderAPIKeyField = "API-Key";
+const reqHeaderAPIKeyField = "x-api-key";
 const asc = "ASC";
 
 dotenv.config();

--- a/controllers/userroom.controller.js
+++ b/controllers/userroom.controller.js
@@ -10,7 +10,7 @@ const success = `🟢${chalk.green("Success:")}`;
 const badAccessError = `🔴${chalk.red("Error:")}`;
 const unknownError = `🟣${purple("Error:")}`;
 const reqHeaderIPField = "X-FORWARDED-FOR";
-const reqHeaderAPIKeyField = "API-Key";
+const reqHeaderAPIKeyField = "x-api-key";
 const asc = "ASC";
 
 dotenv.config();

--- a/controllers/userroom.controller.js
+++ b/controllers/userroom.controller.js
@@ -12,7 +12,6 @@ const unknownError = `🟣${purple("Error:")}`;
 const reqHeaderIPField = "X-FORWARDED-FOR";
 const reqHeaderAPIKeyField = "API-Key";
 const asc = "ASC";
-const userroomLabel = "User-Room";
 
 dotenv.config();
 
@@ -27,13 +26,13 @@ exports.create = (req, res) => {
 
         if (!userID || !roomID) {
             res.status(400).send({
-                message: `${userroomLabel} 테이블의 필수 정보가 누락 되었습니다!`,
+                message: `${UserRoom.name} 테이블의 필수 정보가 누락 되었습니다!`,
             });
             console.log(
                 `[${moment().format(
                     dateFormat
                 )}] ${badAccessError} ${chalk.yellow(
-                    `${userroomLabel} 테이블`
+                    `${UserRoom.name} 테이블`
                 )}의 필수 데이터를 포함하지 않고 Create를 시도했습니다. (IP: ${IP})`
             );
             return;
@@ -49,20 +48,20 @@ exports.create = (req, res) => {
                 res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${userroomLabel} 테이블`
+                        `${UserRoom.name} 테이블`
                     )}에 새로운 데이터가 성공적으로 추가되었습니다. (IP: ${IP})`
                 );
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `새로운 ${userroomLabel} 정보를 추가하는 중에 문제가 발생했습니다.`,
+                    message: `새로운 ${UserRoom.name} 정보를 추가하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} 새로운 ${chalk.yellow(
-                        userroomLabel
+                        UserRoom.name
                     )}을 추가하는 중에 문제가 발생했습니다. ${chalk.dim(
                         `상세정보: ${err.message}`
                     )} (IP: ${IP})`
@@ -89,20 +88,20 @@ exports.findAll = (req, res) => {
                 res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${userroomLabel} 테이블`
+                        `${UserRoom.name} 테이블`
                     )}의 모든 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                 );
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${userroomLabel} 테이블을 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${UserRoom.name} 테이블을 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${userroomLabel} 테이블`
+                        `${UserRoom.name} 테이블`
                     )}을 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
                         `상세정보: ${err.message}`
                     )} (IP: ${IP})`
@@ -133,20 +132,20 @@ exports.findOne = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${userroomLabel} 테이블`
+                            `${UserRoom.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                     );
                 } else {
                     res.status(404).send({
-                        message: `${userroomLabel} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
+                        message: `${UserRoom.name} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${userroomLabel} 테이블`
+                            `${UserRoom.name} 테이블`
                         )}에서 ${chalk.yellow(
                             `${id}번`
                         )} 데이터를 찾을 수 없습니다. (IP: ${IP})`
@@ -155,14 +154,14 @@ exports.findOne = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${userroomLabel} 테이블의 ${id}번 데이터를 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${UserRoom.name} 테이블의 ${id}번 데이터를 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${userroomLabel} 테이블`
+                        `${UserRoom.name} 테이블`
                     )}의 ${chalk.yellow(
                         `${id}번`
                     )} 데이터를 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
@@ -200,33 +199,33 @@ exports.update = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${userroomLabel} 테이블`
+                            `${UserRoom.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터가 성공적으로 수정되었습니다. (IP: ${IP})`
                     );
                 } else if (!userID && !roomID) {
                     res.status(400).send({
-                        message: `U${userroomLabel} 테이블의 ${id}번 데이터의 수정을 시도했지만, request의 body가 비어있어 수정할 수 없습니다.`,
+                        message: `${UserRoom.name} 테이블의 ${id}번 데이터의 수정을 시도했지만, request의 body가 비어있어 수정할 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${userroomLabel} 테이블`
+                            `${UserRoom.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터의 수정을 시도했지만, request의 body가 비어있어 수정할 수 없습니다. (IP: ${IP})`
                     );
                 } else {
                     res.status(404).send({
-                        message: `${userroomLabel} 테이블의 ${id}번 데이터의 수정을 시도했지만, 해당 데이터를 찾을 수 없습니다.`,
+                        message: `${UserRoom.name} 테이블의 ${id}번 데이터의 수정을 시도했지만, 해당 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${userroomLabel} 테이블`
+                            `${UserRoom.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터의 수정을 시도했지만, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
@@ -235,14 +234,14 @@ exports.update = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${userroomLabel} 테이블의 ${id}번 데이터를 수정하는 중에 문제가 발생했습니다.`,
+                    message: `${UserRoom.name} 테이블의 ${id}번 데이터를 수정하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${userroomLabel} 테이블`
+                        `${UserRoom.name} 테이블`
                     )}의 ${chalk.yellow(
                         `${id}번`
                     )} 데이터를 수정하는 중에 문제가 발생했습니다. ${chalk.dim(

--- a/controllers/worker.controller.js
+++ b/controllers/worker.controller.js
@@ -12,7 +12,6 @@ const unknownError = `🟣${purple("Error:")}`;
 const reqHeaderIPField = "X-FORWARDED-FOR";
 const reqHeaderAPIKeyField = "API-Key";
 const asc = "ASC";
-const workerLabel = "Worker";
 
 dotenv.config();
 
@@ -29,13 +28,13 @@ exports.create = (req, res) => {
 
         if (!userID || !userIdentifier || !name || !email) {
             res.status(400).send({
-                message: `${workerLabel} 테이블의 필수 정보가 누락 되었습니다!`,
+                message: `${Worker.name} 테이블의 필수 정보가 누락 되었습니다!`,
             });
             console.log(
                 `[${moment().format(
                     dateFormat
                 )}] ${badAccessError} ${chalk.yellow(
-                    `${workerLabel} 테이블`
+                    `${Worker.name} 테이블`
                 )}의 필수 데이터를 포함하지 않고 Create를 시도했습니다. (IP: ${IP})`
             );
             return;
@@ -53,20 +52,20 @@ exports.create = (req, res) => {
                 res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${workerLabel} 테이블`
+                        `${Worker.name} 테이블`
                     )}에 새로운 데이터가 성공적으로 추가되었습니다. (IP: ${IP})`
                 );
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `새로운 ${workerLabel}를 추가하는 중에 문제가 발생했습니다.`,
+                    message: `새로운 ${Worker.name}를 추가하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} 새로운 ${chalk.yellow(
-                        workerLabel
+                        Worker.name
                     )}를 추가하는 중에 문제가 발생했습니다. ${chalk.dim(
                         `상세정보: ${err.message}`
                     )} (IP: ${IP})`
@@ -93,20 +92,20 @@ exports.findAll = (req, res) => {
                 res.status(200).send(data);
                 console.log(
                     `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
-                        `${workerLabel} 테이블`
+                        `${Worker.name} 테이블`
                     )}의 모든 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                 );
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${workerLabel} 테이블을 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${Worker.name} 테이블을 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${workerLabel} 테이블`
+                        `${Worker.name} 테이블`
                     )}을 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
                         `상세정보: ${err.message}`
                     )} (IP: ${IP})`
@@ -137,20 +136,20 @@ exports.findOne = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${workerLabel} 테이블`
+                            `${Worker.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                     );
                 } else {
                     res.status(404).send({
-                        message: `${workerLabel} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
+                        message: `${Worker.name} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${workerLabel} 테이블`
+                            `${Worker.name} 테이블`
                         )}에서 ${chalk.yellow(
                             `${id}번`
                         )} 데이터를 찾을 수 없습니다. (IP: ${IP})`
@@ -159,14 +158,14 @@ exports.findOne = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${workerLabel} 테이블의 ${id}번 데이터를 조회하는 중에 문제가 발생했습니다.`,
+                    message: `${Worker.name} 테이블의 ${id}번 데이터를 조회하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${workerLabel} 테이블`
+                        `${Worker.name} 테이블`
                     )}의 ${chalk.yellow(
                         `${id}번`
                     )} 데이터를 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
@@ -197,13 +196,13 @@ exports.update = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         if (userID) {
             res.status(400).send({
-                message: `${workerLabel} 테이블의 ${id}번 데이터의 userID를 ${userID}로 변경할 수 없습니다.`,
+                message: `${Worker.name} 테이블의 ${id}번 데이터의 userID를 ${userID}로 변경할 수 없습니다.`,
             });
             console.log(
                 `[${moment().format(
                     dateFormat
                 )}] ${badAccessError} ${chalk.yellow(
-                    `${workerLabel} 테이블`
+                    `${Worker.name} 테이블`
                 )}의 ${chalk.yellow(
                     `${id}번`
                 )} 데이터의 userID를 ${chalk.yellow(
@@ -224,33 +223,33 @@ exports.update = (req, res) => {
                         `[${moment().format(
                             dateFormat
                         )}] ${success} ${chalk.yellow(
-                            `${workerLabel} 테이블`
+                            `${Worker.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터가 성공적으로 수정되었습니다. (IP: ${IP})`
                     );
                 } else if (!userIdentifier && !name && !email) {
                     res.status(400).send({
-                        message: `${workerLabel} 테이블의 ${id}번 데이터의 수정을 시도했지만, request의 body가 비어있어 수정할 수 없습니다.`,
+                        message: `${Worker.name} 테이블의 ${id}번 데이터의 수정을 시도했지만, request의 body가 비어있어 수정할 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${workerLabel} 테이블`
+                            `${Worker.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터의 수정을 시도했지만, request의 body가 비어있어 수정할 수 없습니다. (IP: ${IP})`
                     );
                 } else {
                     res.status(404).send({
-                        message: `${workerLabel} 테이블의 ${id}번 데이터의 수정을 시도했지만, 해당 데이터를 찾을 수 없습니다.`,
+                        message: `${Worker.name} 테이블의 ${id}번 데이터의 수정을 시도했지만, 해당 데이터를 찾을 수 없습니다.`,
                     });
                     console.log(
                         `[${moment().format(
                             dateFormat
                         )}] ${badAccessError} ${chalk.yellow(
-                            `${workerLabel} 테이블`
+                            `${Worker.name} 테이블`
                         )}의 ${chalk.yellow(
                             `${id}번`
                         )} 데이터의 수정을 시도했지만, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
@@ -259,14 +258,14 @@ exports.update = (req, res) => {
             })
             .catch((err) => {
                 res.status(500).send({
-                    message: `${workerLabel} 테이블의 ${id}번 데이터를 수정하는 중에 문제가 발생했습니다.`,
+                    message: `${Worker.name} 테이블의 ${id}번 데이터를 수정하는 중에 문제가 발생했습니다.`,
                     detail: err.message,
                 });
                 console.log(
                     `[${moment().format(
                         dateFormat
                     )}] ${unknownError} ${chalk.yellow(
-                        `${workerLabel} 테이블`
+                        `${Worker.name} 테이블`
                     )}의 ${chalk.yellow(
                         `${id}번`
                     )} 데이터를 수정하는 중에 문제가 발생했습니다. ${chalk.dim(

--- a/controllers/worker.controller.js
+++ b/controllers/worker.controller.js
@@ -10,7 +10,7 @@ const success = `🟢${chalk.green("Success:")}`;
 const badAccessError = `🔴${chalk.red("Error:")}`;
 const unknownError = `🟣${purple("Error:")}`;
 const reqHeaderIPField = "X-FORWARDED-FOR";
-const reqHeaderAPIKeyField = "API-Key";
+const reqHeaderAPIKeyField = "x-api-key";
 const asc = "ASC";
 
 dotenv.config();

--- a/models/category.model.js
+++ b/models/category.model.js
@@ -1,6 +1,6 @@
 module.exports = (sequelize, Sequelize) => {
     const Category = sequelize.define(
-        "category",
+        "Category",
         {
             categoryID: {
                 type: Sequelize.INTEGER,

--- a/models/photo.model.js
+++ b/models/photo.model.js
@@ -1,6 +1,6 @@
 module.exports = (sequelize, Sequelize) => {
     const Photo = sequelize.define(
-        "photo",
+        "Photo",
         {
             photoID: {
                 type: Sequelize.INTEGER,

--- a/models/post.model.js
+++ b/models/post.model.js
@@ -1,6 +1,6 @@
 module.exports = (sequelize, Sequelize) => {
     const Post = sequelize.define(
-        "post",
+        "Post",
         {
             postID: {
                 type: Sequelize.INTEGER,

--- a/models/room.model.js
+++ b/models/room.model.js
@@ -1,6 +1,6 @@
 module.exports = (sequelize, Sequelize) => {
     const Room = sequelize.define(
-        "room",
+        "Room",
         {
             roomID: {
                 type: Sequelize.INTEGER,

--- a/models/user.model.js
+++ b/models/user.model.js
@@ -1,6 +1,6 @@
 module.exports = (sequelize, Sequelize) => {
     const User = sequelize.define(
-        "user",
+        "User",
         {
             userID: {
                 type: Sequelize.INTEGER,

--- a/models/userroom.model.js
+++ b/models/userroom.model.js
@@ -1,6 +1,6 @@
 module.exports = (sequelize, Sequelize) => {
     const UserRoom = sequelize.define(
-        "userroom",
+        "User-Room",
         {
             userRoomID: {
                 type: Sequelize.INTEGER,

--- a/models/worker.model.js
+++ b/models/worker.model.js
@@ -1,6 +1,6 @@
 module.exports = (sequelize, Sequelize) => {
     const Worker = sequelize.define(
-        "worker",
+        "Worker",
         {
             userID: {
                 type: Sequelize.INTEGER,

--- a/utils/s3.utils.js
+++ b/utils/s3.utils.js
@@ -7,6 +7,7 @@ const moment = require("moment");
 const dotenv = require("dotenv");
 const chalk = require("chalk");
 
+const reqHeaderAPIKeyField = "x-api-key";
 dotenv.config();
 
 AWS.config.update({
@@ -35,7 +36,7 @@ const imageUploader = multer({
         s3: s3,
         bucket: process.env.AWS_BUCKET_NAME,
         key: (req, file, callback) => {
-            if (req.header("API-Key") == process.env.API_KEY) {
+            if (req.header(reqHeaderAPIKeyField) == process.env.API_KEY) {
                 const uploadDirectory = "photos";
                 const extension = path.extname(file.originalname);
                 if (!allowedExtensions.includes(extension)) {

--- a/utils/s3.utils.js
+++ b/utils/s3.utils.js
@@ -7,7 +7,12 @@ const moment = require("moment");
 const dotenv = require("dotenv");
 const chalk = require("chalk");
 
+const reqHeaderIPField = "X-FORWARDED-FOR";
 const reqHeaderAPIKeyField = "x-api-key";
+
+const success = `🟢${chalk.green("Success:")}`;
+const badAccessError = `🔴${chalk.red("Error:")}`;
+
 dotenv.config();
 
 AWS.config.update({
@@ -36,27 +41,25 @@ const imageUploader = multer({
         s3: s3,
         bucket: process.env.AWS_BUCKET_NAME,
         key: (req, file, callback) => {
+            const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
+
             if (req.header(reqHeaderAPIKeyField) == process.env.API_KEY) {
                 const uploadDirectory = "photos";
                 const extension = path.extname(file.originalname);
                 if (!allowedExtensions.includes(extension)) {
                     console.log(
-                        `[${moment().format("YYYY-MM-DD HH:mm:ss.SSS")}] ` +
-                            chalk.bgRed("Error:") +
-                            " Not Allowed Extension (IP: " +
-                            (req.header("X-FORWARDED-FOR") ||
-                                req.socket.remoteAddress) +
-                            ")"
+                        `[${moment().format(
+                            "YYYY-MM-DD HH:mm:ss.SSS"
+                        )}] ${badAccessError} 허용되지 않은 확장자(${chalk.yellow(
+                            extension
+                        )})로 업로드를 시도했습니다. (IP: ${IP})`
                     );
                     return callback(new Error("wrong extension"));
                 }
                 console.log(
-                    `[${moment().format("YYYY-MM-DD HH:mm:ss.SSS")}] ` +
-                        chalk.bgGreen("Success:") +
-                        "사진 업로드에 성공했습니다. (IP: " +
-                        (req.header("X-FORWARDED-FOR") ||
-                            req.socket.remoteAddress) +
-                        ")"
+                    `[${moment().format(
+                        "YYYY-MM-DD HH:mm:ss.SSS"
+                    )}] ${success} 성공적으로 사진을 업로드 했습니다. (IP: ${IP})`
                 );
                 callback(
                     null,
@@ -66,12 +69,9 @@ const imageUploader = multer({
                 );
             } else {
                 console.log(
-                    `[${moment().format("YYYY-MM-DD HH:mm:ss.SSS")}] ` +
-                        chalk.bgRed("Error:") +
-                        " Connection Fail at Image Uploader (IP: " +
-                        (req.header("X-FORWARDED-FOR") ||
-                            req.socket.remoteAddress) +
-                        ")"
+                    `[${moment().format(
+                        "YYYY-MM-DD HH:mm:ss.SSS"
+                    )}] ${badAccessError} Connection Fail at Image Uploader (IP: ${IP})`
                 );
                 return callback(new Error("Connection Fail"));
             }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 병합된 데이터 테이블의 데이터 순서 정렬이 제대로 되고 있지 않는 문제
  - 병합된 데이터 테이블들을 대상으로 Get 메서드로 데이터를 불러왔을 때, 데이터 순서가 id 순으로 정렬되지 않고, 최근 수정 데이터가 맨 뒤로 가는 현상을 발견 
- 레이블로 하드 코딩 되어 있던 테이블 이름 모델의 어트리뷰트로 변경
  - 기존에 어떤 테이블인지 보여주기 위해 하드 코딩 되어있던 테이블 이름을 레이블이라는 변수로 뺐었음
  - 테이블 이름을 저장하고 있던 Model.name 이라는 어트리뷰트 발견으로 해당 어트리뷰트로 변경하기 위함
- apiKey를 확장 제공하는 필드로 받아오기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- Sequelize의 병합 테이블 데이터 정렬 방법으로 병합된 데이터 테이블의 데이터 순서를 id 순으로 제대로 정렬
- 모델의 이름 첫글자 대문자로 변경 (`user` => `User`, `worker` => `Worker` 등)
- 레이블로 작성된 테이블 이름 어트리뷰트로 변경 (`userLabel` => `User.name`, `workerLabel` => `Worker.name` 등)
- `API-Key`로 받아오던 apikey를 `x-api-key` 필드로 받아오도록 변경
- 이미지 업로더 로그 수정

## ToDo 📆 (남은 작업)
- [ ] 없음

## ScreenShot 📷 (참고 사진)
|수정 전|수정 후|
|:-:|:-:|
|<img src="https://user-images.githubusercontent.com/81027256/216830890-5cc29750-3c4f-4b62-b7d7-73032a08769a.png">|<img src="https://user-images.githubusercontent.com/81027256/216830901-0b04f0b2-9dab-488a-b8d0-c0f1c6907451.png">|

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- Sequelize의 Joined Table order가 상위 테이블에서만 먹는다는 것을 모르고 구현했다가 문제를 발견하여 수정합니다.
- 혹시나 싶어서 이것저것 만져보다가 name이라는 어트리뷰트가 있길래 해당 어트리뷰트로 변경하여 반영했습니다.
- Sequelize 문법이 버전마다 조금씩 다르다보니 올바른 레퍼런스 찾기가 어렵네요. 레퍼런스만 있었어도 name 어트리뷰트를 진작에 사용했을 텐데, 이걸 직접 발견해야 한다는 게 참...
- 기존 62 PR의 내용도 해당 PR로 합쳐졌습니다.
- 추가로 apiKey 부분을 받아오는 헤더 필드를 변경하고, 이미지 업로드에 반영되지 않아있던 로그 스타일을 변경했습니다.
- 급한 수정 사항들이 다 반영되다 보니 라인수가 길어졌습니다. 양해 부탁드려요.

## Reference 🔗
- [CHAN_STUDIO - sequelize include 안에 order](https://m.blog.naver.com/kimhecan/222030104760)

## Close Issues 🔒 (닫을 Issue)
- Close #60.
- Close #61.
- Close #66.
