### PR TITLE
[Feature] 특정 테이블의 데이터 삭제 기능 추가

### DIFF
--- a/controllers/photo.controller.js
+++ b/controllers/photo.controller.js
@@ -260,3 +260,69 @@ exports.update = (req, res) => {
         );
     }
 };
+
+exports.delete = (req, res) => {
+    const id = req.params.id;
+    const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
+
+    if (req.header(reqHeaderAPIKeyField) == apiKey) {
+        Photo.destroy({
+            where: { photoID: id },
+        })
+            .then((num) => {
+                if (num == 1) {
+                    res.status(200).send({
+                        message: `${Photo.name} 테이블의 ${id}번 데이터가 성공적으로 삭제되었습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${Photo.name} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터가 성공적으로 삭제되었습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${Photo.name} 테이블에서 ${id}번 데이터의 삭제를 시도했으나, 해당 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${Photo.name} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터의 삭제를 시도했으나, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
+            })
+            .catch((err) => {
+                res.status(500).send({
+                    message: `${Photo.name} 테이블의 ${id}번 데이터를 삭제하는 중에 문제가 발생했습니다.`,
+                    detail: err.message,
+                });
+                console.log(
+                    `[${moment().format(
+                        dateFormat
+                    )}] ${unknownError} ${chalk.yellow(
+                        `${Photo.name} 테이블`
+                    )}의 ${chalk.yellow(
+                        `${id}번`
+                    )} 데이터를 삭제하는 중에 문제가 발생했습니다. ${chalk.dim(
+                        "상세정보: " + err.message
+                    )} (IP: ${IP})`
+                );
+            });
+    } else {
+        res.status(403).send({ message: "Connection Fail" });
+        console.log(
+            `[${moment().format(
+                dateFormat
+            )}] ${badAccessError} Connection Fail at ${chalk.yellow(
+                "DELETE /photos/${id}"
+            )} (IP: ${IP})`
+        );
+    }
+};

--- a/controllers/room.controller.js
+++ b/controllers/room.controller.js
@@ -244,10 +244,11 @@ exports.findOneWithCategory = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Room.findOne({
             where: { roomID: id },
-            order: [[Category, "categoryID", asc]],
+            order: [["categories", "categoryID", asc]],
             include: [
                 {
                     model: Category,
+                    as: "categories",
                     attributes: ["categoryID", "name", "progress"],
                 },
             ],
@@ -315,10 +316,11 @@ exports.findOneWithPost = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Room.findOne({
             where: { roomID: id },
-            order: [[Post, "postID", asc]],
+            order: [["posts", "postID", asc]],
             include: [
                 {
                     model: Post,
+                    as: "posts",
                     attributes: [
                         "postID",
                         "userID",
@@ -326,10 +328,11 @@ exports.findOneWithPost = (req, res) => {
                         "description",
                         "createDate",
                     ],
-                    order: [[Photo, "photoID", asc]],
+                    order: [["photos", "photoID", asc]],
                     include: [
                         {
                             model: Photo,
+                            as: "photos",
                             attributes: ["photoID", "url"],
                         },
                     ],
@@ -349,7 +352,9 @@ exports.findOneWithPost = (req, res) => {
                         )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                     );
                 } else {
-                    res.status(404).send(data);
+                    res.status(404).send({
+                        message: `${Room.name} + ${Post.name} + ${Photo.name} 테이블의 roomID=${id}번 데이터를 찾을 수 없습니다.`,
+                    });
                     console.log(
                         `[${moment().format(
                             dateFormat
@@ -397,25 +402,28 @@ exports.findOneWithCategoryAndPost = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Room.findOne({
             where: { roomID: id },
-            order: [[Category, "categoryID", asc]],
+            order: [["categories", "categoryID", asc]],
             include: [
                 {
                     model: Category,
+                    as: "categories",
                     attributes: ["categoryID", "name", "progress"],
-                    order: [[Post, "postID", asc]],
+                    order: [["posts", "postID", asc]],
                     include: [
                         {
                             model: Post,
+                            as: "posts",
                             attributes: [
                                 "postID",
                                 "userID",
                                 "description",
                                 "createDate",
                             ],
-                            order: [[Photo, "photoID", asc]],
+                            order: [["photos", "photoID", asc]],
                             include: [
                                 {
                                     model: Photo,
+                                    as: "photos",
                                     attributes: ["photoID", "url"],
                                 },
                             ],
@@ -485,24 +493,27 @@ exports.findOneWithPostAndCategory = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Room.findOne({
             where: { roomID: id },
-            order: [[Post, "postID", asc]],
+            order: [["posts", "postID", asc]],
             include: [
                 {
                     model: Post,
+                    as: "posts",
                     attributes: [
                         "postID",
                         "userID",
                         "description",
                         "createDate",
                     ],
-                    order: [[Photo, "photoID", asc]],
+                    order: [["photos", "photoID", asc]],
                     include: [
                         {
                             model: Category,
+                            as: "category",
                             attributes: ["categoryID", "name"],
                         },
                         {
                             model: Photo,
+                            as: "photos",
                             attributes: ["photoID", "url"],
                         },
                     ],
@@ -570,18 +581,21 @@ exports.findOneWithUser = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         Room.findOne({
             where: { roomID: id },
-            order: [[UserRoom, "userID", asc]],
+            order: [["userrooms", "userID", asc]],
             include: [
                 {
                     model: UserRoom,
+                    as: "userrooms",
                     attributes: ["userID"],
                     include: [
                         {
                             model: User,
+                            as: "user",
                             attributes: ["number"],
                             include: [
                                 {
                                     model: Worker,
+                                    as: "worker",
                                     attributes: [
                                         "userIdentifier",
                                         "name",
@@ -607,14 +621,16 @@ exports.findOneWithUser = (req, res) => {
                         )}인 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
                     );
                 } else {
-                    res.status(404).send(data);
+                    res.status(404).send({
+                        message: `${Room.name} + ${UserRoom.name} + ${User.name} + ${Worker.name} 테이블에서 ${id}번 데이터를 찾을 수 없습니다.`,
+                    });
                     console.log(
                         `[${moment().format(
                             dateFormat
-                        )}] ${success} ${chalk.yellow(
+                        )}] ${badAccessError} ${chalk.yellow(
                             `${Room.name} + ${UserRoom.name} + ${User.name} + ${Worker.name} 테이블`
                         )}의 ${chalk.yellow(
-                            `roomID=${id}`
+                            `postID=${id}`
                         )}인 데이터를 찾을 수 없습니다. (IP: ${IP})`
                     );
                 }
@@ -744,6 +760,72 @@ exports.update = (req, res) => {
                 dateFormat
             )}] ${badAccessError} Connection Fail at ${chalk.yellow(
                 `PUT /rooms/${id}`
+            )} (IP: ${IP})`
+        );
+    }
+};
+
+exports.delete = (req, res) => {
+    const id = req.params.id;
+    const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
+
+    if (req.header(reqHeaderAPIKeyField) == apiKey) {
+        Room.destroy({
+            where: { roomID: id },
+        })
+            .then((num) => {
+                if (num == 1) {
+                    res.status(200).send({
+                        message: `${Room.name} 테이블의 ${id}번 데이터가 성공적으로 삭제되었습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${Room.name} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터가 성공적으로 삭제되었습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${Room.name} 테이블에서 ${id}번 데이터의 삭제를 시도했으나, 해당 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${Room.name} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터의 삭제를 시도했으나, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
+            })
+            .catch((err) => {
+                res.status(500).send({
+                    message: `${Room.name} 테이블의 ${id}번 데이터를 삭제하는 중에 문제가 발생했습니다.`,
+                    detail: err.message,
+                });
+                console.log(
+                    `[${moment().format(
+                        dateFormat
+                    )}] ${unknownError} ${chalk.yellow(
+                        `${Room.name} 테이블`
+                    )}의 ${chalk.yellow(
+                        `${id}번`
+                    )} 데이터를 삭제하는 중에 문제가 발생했습니다. ${chalk.dim(
+                        "상세정보: " + err.message
+                    )} (IP: ${IP})`
+                );
+            });
+    } else {
+        res.status(403).send({ message: "Connection Fail" });
+        console.log(
+            `[${moment().format(
+                dateFormat
+            )}] ${badAccessError} Connection Fail at ${chalk.yellow(
+                "DELETE /rooms/${id}"
             )} (IP: ${IP})`
         );
     }

--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -73,6 +73,7 @@ exports.findAll = (req, res) => {
             include: [
                 {
                     model: Worker,
+                    as: "worker",
                     attributes: ["userIdentifier", "name", "email"],
                 },
             ],
@@ -122,6 +123,7 @@ exports.findOne = (req, res) => {
             include: [
                 {
                     model: Worker,
+                    as: "worker",
                     attributes: ["userIdentifier", "name", "email"],
                 },
             ],
@@ -189,18 +191,21 @@ exports.findOneWithRoom = (req, res) => {
     if (req.header(reqHeaderAPIKeyField) == apiKey) {
         User.findOne({
             where: { userID: id },
-            order: [[UserRoom, "roomID", asc]],
+            order: [["userrooms", "roomID", asc]],
             include: [
                 {
                     model: Worker,
+                    as: "worker",
                     attributes: ["userIdentifier", "name", "email"],
                 },
                 {
                     model: UserRoom,
+                    as: "userrooms",
                     attributes: ["roomID"],
                     include: [
                         {
                             model: Room,
+                            as: "room",
                             attributes: [
                                 "name",
                                 "startDate",
@@ -343,6 +348,72 @@ exports.update = (req, res) => {
                 dateFormat
             )}] ${badAccessError} Connection Fail at ${chalk.yellow(
                 "PUT /users/${id}"
+            )} (IP: ${IP})`
+        );
+    }
+};
+
+exports.delete = (req, res) => {
+    const id = req.params.id;
+    const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
+
+    if (req.header(reqHeaderAPIKeyField) == apiKey) {
+        User.destroy({
+            where: { userID: id },
+        })
+            .then((num) => {
+                if (num == 1) {
+                    res.status(200).send({
+                        message: `${User.name} 테이블의 ${id}번 데이터가 성공적으로 삭제되었습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${User.name} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터가 성공적으로 삭제되었습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${User.name} 테이블에서 ${id}번 데이터의 삭제를 시도했으나, 해당 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${User.name} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터의 삭제를 시도했으나, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
+            })
+            .catch((err) => {
+                res.status(500).send({
+                    message: `${User.name} 테이블의 ${id}번 데이터를 삭제하는 중에 문제가 발생했습니다.`,
+                    detail: err.message,
+                });
+                console.log(
+                    `[${moment().format(
+                        dateFormat
+                    )}] ${unknownError} ${chalk.yellow(
+                        `${User.name} 테이블`
+                    )}의 ${chalk.yellow(
+                        `${id}번`
+                    )} 데이터를 삭제하는 중에 문제가 발생했습니다. ${chalk.dim(
+                        "상세정보: " + err.message
+                    )} (IP: ${IP})`
+                );
+            });
+    } else {
+        res.status(403).send({ message: "Connection Fail" });
+        console.log(
+            `[${moment().format(
+                dateFormat
+            )}] ${badAccessError} Connection Fail at ${chalk.yellow(
+                "DELETE /users/${id}"
             )} (IP: ${IP})`
         );
     }

--- a/controllers/userroom.controller.js
+++ b/controllers/userroom.controller.js
@@ -260,3 +260,69 @@ exports.update = (req, res) => {
         );
     }
 };
+
+exports.delete = (req, res) => {
+    const id = req.params.id;
+    const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
+
+    if (req.header(reqHeaderAPIKeyField) == apiKey) {
+        UserRoom.destroy({
+            where: { userRoomID: id },
+        })
+            .then((num) => {
+                if (num == 1) {
+                    res.status(200).send({
+                        message: `${UserRoom.name} 테이블의 ${id}번 데이터가 성공적으로 삭제되었습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${UserRoom.name} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터가 성공적으로 삭제되었습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${UserRoom.name} 테이블에서 ${id}번 데이터의 삭제를 시도했으나, 해당 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${UserRoom.name} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터의 삭제를 시도했으나, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
+            })
+            .catch((err) => {
+                res.status(500).send({
+                    message: `${UserRoom.name} 테이블의 ${id}번 데이터를 삭제하는 중에 문제가 발생했습니다.`,
+                    detail: err.message,
+                });
+                console.log(
+                    `[${moment().format(
+                        dateFormat
+                    )}] ${unknownError} ${chalk.yellow(
+                        `${UserRoom.name} 테이블`
+                    )}의 ${chalk.yellow(
+                        `${id}번`
+                    )} 데이터를 삭제하는 중에 문제가 발생했습니다. ${chalk.dim(
+                        "상세정보: " + err.message
+                    )} (IP: ${IP})`
+                );
+            });
+    } else {
+        res.status(403).send({ message: "Connection Fail" });
+        console.log(
+            `[${moment().format(
+                dateFormat
+            )}] ${badAccessError} Connection Fail at ${chalk.yellow(
+                "DELETE /user-rooms/${id}"
+            )} (IP: ${IP})`
+        );
+    }
+};

--- a/controllers/worker.controller.js
+++ b/controllers/worker.controller.js
@@ -284,3 +284,69 @@ exports.update = (req, res) => {
         );
     }
 };
+
+exports.delete = (req, res) => {
+    const id = req.params.id;
+    const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
+
+    if (req.header(reqHeaderAPIKeyField) == apiKey) {
+        Worker.destroy({
+            where: { userID: id },
+        })
+            .then((num) => {
+                if (num == 1) {
+                    res.status(200).send({
+                        message: `${Worker.name} 테이블의 ${id}번 데이터가 성공적으로 삭제되었습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${success} ${chalk.yellow(
+                            `${Worker.name} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터가 성공적으로 삭제되었습니다. (IP: ${IP})`
+                    );
+                } else {
+                    res.status(404).send({
+                        message: `${Worker.name} 테이블에서 ${id}번 데이터의 삭제를 시도했으나, 해당 데이터를 찾을 수 없습니다.`,
+                    });
+                    console.log(
+                        `[${moment().format(
+                            dateFormat
+                        )}] ${badAccessError} ${chalk.yellow(
+                            `${Worker.name} 테이블`
+                        )}의 ${chalk.yellow(
+                            `${id}번`
+                        )} 데이터의 삭제를 시도했으나, 해당 데이터를 찾을 수 없습니다. (IP: ${IP})`
+                    );
+                }
+            })
+            .catch((err) => {
+                res.status(500).send({
+                    message: `${Worker.name} 테이블의 ${id}번 데이터를 삭제하는 중에 문제가 발생했습니다.`,
+                    detail: err.message,
+                });
+                console.log(
+                    `[${moment().format(
+                        dateFormat
+                    )}] ${unknownError} ${chalk.yellow(
+                        `${Worker.name} 테이블`
+                    )}의 ${chalk.yellow(
+                        `${id}번`
+                    )} 데이터를 삭제하는 중에 문제가 발생했습니다. ${chalk.dim(
+                        "상세정보: " + err.message
+                    )} (IP: ${IP})`
+                );
+            });
+    } else {
+        res.status(403).send({ message: "Connection Fail" });
+        console.log(
+            `[${moment().format(
+                dateFormat
+            )}] ${badAccessError} Connection Fail at ${chalk.yellow(
+                "DELETE /workers/${id}"
+            )} (IP: ${IP})`
+        );
+    }
+};

--- a/models/index.js
+++ b/models/index.js
@@ -33,28 +33,37 @@ Object.keys(db).forEach((modelName) => {
     }
 });
 
-db["users"].hasOne(db["workers"], { foreignKey: "userID" });
-db["workers"].belongsTo(db["users"], { foreignKey: "userID" });
+db["users"].hasOne(db["workers"], { as: "worker", foreignKey: "userID" });
+db["workers"].belongsTo(db["users"], { as: "user", foreignKey: "userID" });
 
-db["users"].hasMany(db["userrooms"], { foreignKey: "userID" });
-db["userrooms"].belongsTo(db["users"], { foreignKey: "userID" });
+db["users"].hasMany(db["userrooms"], { as: "userrooms", foreignKey: "userID" });
+db["userrooms"].belongsTo(db["users"], { as: "user", foreignKey: "userID" });
 
-db["rooms"].hasMany(db["userrooms"], { foreignKey: "roomID" });
-db["userrooms"].belongsTo(db["rooms"], { foreignKey: "roomID" });
+db["rooms"].hasMany(db["userrooms"], { as: "userrooms", foreignKey: "roomID" });
+db["userrooms"].belongsTo(db["rooms"], { as: "room", foreignKey: "roomID" });
 
-db["rooms"].hasMany(db["categories"], { foreignKey: "roomID" });
-db["categories"].belongsTo(db["rooms"], { foreignKey: "roomID" });
+db["rooms"].hasMany(db["categories"], {
+    as: "categories",
+    foreignKey: "roomID",
+});
+db["categories"].belongsTo(db["rooms"], { as: "room", foreignKey: "roomID" });
 
-db["categories"].hasMany(db["posts"], { foreignKey: "categoryID" });
-db["posts"].belongsTo(db["categories"], { foreignKey: "categoryID" });
+db["categories"].hasMany(db["posts"], {
+    as: "posts",
+    foreignKey: "categoryID",
+});
+db["posts"].belongsTo(db["categories"], {
+    as: "category",
+    foreignKey: "categoryID",
+});
 
-db["users"].hasMany(db["posts"], { foreignKey: "userID" });
-db["posts"].belongsTo(db["users"], { foreignKey: "userID" });
+db["users"].hasMany(db["posts"], { as: "posts", foreignKey: "userID" });
+db["posts"].belongsTo(db["users"], { as: "user", foreignKey: "userID" });
 
-db["rooms"].hasMany(db["posts"], { foreignKey: "roomID" });
-db["posts"].belongsTo(db["rooms"], { foreignKey: "roomID" });
+db["rooms"].hasMany(db["posts"], { as: "posts", foreignKey: "roomID" });
+db["posts"].belongsTo(db["rooms"], { as: "room", foreignKey: "roomID" });
 
-db["posts"].hasMany(db["photos"], { foreignKey: "postID" });
-db["photos"].belongsTo(db["posts"], { foreignKey: "postID" });
+db["posts"].hasMany(db["photos"], { as: "photos", foreignKey: "postID" });
+db["photos"].belongsTo(db["posts"], { as: "post", foreignKey: "postID" });
 
 module.exports = db;

--- a/routes/category.routes.js
+++ b/routes/category.routes.js
@@ -11,5 +11,7 @@ module.exports = (app) => {
 
     router.put("/:id", categories.update);
 
+    router.delete("/:id", categories.delete);
+
     app.use("/giwazip/categories", router);
 };

--- a/routes/photo.routes.js
+++ b/routes/photo.routes.js
@@ -12,5 +12,7 @@ module.exports = (app) => {
 
     router.put("/:id", photos.update);
 
+    router.delete("/:id", photos.delete);
+
     app.use("/giwazip/photos", router);
 };

--- a/routes/post.routes.js
+++ b/routes/post.routes.js
@@ -11,5 +11,7 @@ module.exports = (app) => {
 
     router.put("/:id", posts.update);
 
+    router.delete("/:id", posts.delete);
+
     app.use("/giwazip/posts", router);
 };

--- a/routes/room.routes.js
+++ b/routes/room.routes.js
@@ -15,5 +15,7 @@ module.exports = (app) => {
 
     router.put("/:id", rooms.update);
 
+    router.delete("/:id", rooms.delete);
+
     app.use("/giwazip/rooms", router);
 };

--- a/routes/user.routes.js
+++ b/routes/user.routes.js
@@ -11,5 +11,7 @@ module.exports = (app) => {
 
     router.put("/:id", users.update);
 
+    router.delete("/:id", users.delete);
+
     app.use("/giwazip/users", router);
 };

--- a/routes/userroom.routes.js
+++ b/routes/userroom.routes.js
@@ -10,5 +10,7 @@ module.exports = (app) => {
 
     router.put("/:id", userrooms.update);
 
+    router.delete("/:id", userrooms.delete);
+
     app.use("/giwazip/user-rooms", router);
 };

--- a/routes/worker.routes.js
+++ b/routes/worker.routes.js
@@ -10,5 +10,7 @@ module.exports = (app) => {
 
     router.put("/:id", workers.update);
 
+    router.delete("/:id", workers.delete);
+
     app.use("/giwazip/workers", router);
 };


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 특정 테이블의 특정 데이터를 삭제하기 위함
- 결합된 데이터 테이블에서 자식 테이블의 이름이 대문자로 출력되는 문제를 해결하기 위함
- 테이블들의 일부 메서드에서 404를 반환할 때, 로그에 성공으로 출력되는 문제를 해결하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- 특정 테이블의 데이터 삭제 기능 추가
  - 특정 사용자 삭제 (`users.delete`)
  - 특정 업자 삭제 (`workers.delete`)
  - 특정 방 삭제 (`rooms.delete`)
  - 특정 사용자-방 정보 삭제 (`userrooms.delete`)
  - 특정 카테고리 삭제 (`categories.delete`)
  - 특정 게시물 삭제 (`posts.delete`)
  - 특정 사진 삭제 (`photos.delete`)
- 결합된 데이터 테이블의 자식 테이블 이름을 소문자로 출력하도록 변경 (`as` 구문)
- 테이블들의 일부 메서드에서 404를 반환할 때, 로그를 실패로 변경

## ToDo 📆 (남은 작업)
- [ ] 결합 데이터 추가 기능

## ScreenShot 📷 (참고 사진)
- 없음

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 모든 테이블들의 삭제 기능을 한꺼번에 추가하다보니 PR이 좀 커졌습니다.
- 결합 테이블에서 자식 테이블이 대문자로 출력되던 문제를 해결했습니다.
- 약간의 로그 오류가 있어서 수정했습니다.
- 라인이 길지만 어렵지 않은 코드 입니다. 꼼꼼히 살펴보시길 부탁드립니다.

## Reference 🔗
- [Yangeok - Sequelize 테이블 별명 사용하기](https://yangeok.github.io/node.js/2018/12/26/sequelize-association.html)

## Close Issues 🔒 (닫을 Issue)
- Close #65.
- Close #67 
