### PR TITLE
[Chore] 진행률 데이터 타입 정수에서 실수로 변경

### DIFF
--- a/models/category.model.js
+++ b/models/category.model.js
@@ -20,7 +20,7 @@ module.exports = (sequelize, Sequelize) => {
                 field: "name",
             },
             progress: {
-                type: Sequelize.INTEGER,
+                type: (Sequelize.DECIMAL.types.postgres = ["numeric"]),
                 defaultValue: 0,
                 allowNull: false,
                 field: "progress",


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 진행률을 정수가 아닌 실수로 저장하여 클라이언트에서 더 쉽게 사용하게 하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- Category Model의 Progress Type Numeric으로 변경

## ToDo 📆 (남은 작업)
- [ ] 없음

## ScreenShot 📷 (참고 사진)
- 없음

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 데이터 타입만 변경된 1줄짜리 간단한 PR 입니다. 가볍게 확인해주셔도 좋습니다. 감사합니다~

## Reference 🔗
- [Sequelize Repository - PostgreSQL NUMERIC data type support](https://github.com/sequelize/sequelize/issues/10440)

## Close Issues 🔒 (닫을 Issue)
- Close #76.
