### PR TITLE
[Chore] 전체 공지사항 조회 기능 분리

### DIFF
--- a/controllers/notice.controller.js
+++ b/controllers/notice.controller.js
@@ -16,12 +16,13 @@ const asc = "ASC";
 
 dotenv.config();
 
-const apiKey = process.env.ADMIN_KEY;
+const adminKey = process.env.ADMIN_KEY;
+const apiKey = process.env.API_KEY;
 
 exports.create = (req, res) => {
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
 
-    if (req.header(reqHeaderAPIKeyField) == apiKey) {
+    if (req.header(reqHeaderAPIKeyField) == adminKey) {
         let adminID = req.body.adminID;
         let title = req.body.title;
         let content = req.body.content;
@@ -135,7 +136,7 @@ exports.findAll = (req, res) => {
 exports.findAllWithAdmin = (req, res) => {
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
 
-    if (req.header(reqHeaderAPIKeyField) == apiKey) {
+    if (req.header(reqHeaderAPIKeyField) == adminKey) {
         Notice.findAll({
             order: [["noticeID", asc]],
             attributes: [
@@ -188,7 +189,7 @@ exports.findOne = (req, res) => {
     const id = req.params.id;
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
 
-    if (req.header(reqHeaderAPIKeyField) == apiKey) {
+    if (req.header(reqHeaderAPIKeyField) == adminKey) {
         Notice.findOne({
             where: { noticeID: id },
             order: [["noticeID", asc]],
@@ -268,7 +269,7 @@ exports.update = (req, res) => {
     const isHidden = req.body.isHidden;
     const adminID = req.body.adminID;
 
-    if (req.header(reqHeaderAPIKeyField) == apiKey) {
+    if (req.header(reqHeaderAPIKeyField) == adminKey) {
         if (createDate) {
             res.status(400).send({
                 message: `${Notice.name} 테이블의 ${id}번 데이터의 createDate를 ${createDate}로 변경할 수 없습니다.`,
@@ -364,7 +365,7 @@ exports.delete = (req, res) => {
     const id = req.params.id;
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
 
-    if (req.header(reqHeaderAPIKeyField) == apiKey) {
+    if (req.header(reqHeaderAPIKeyField) == adminKey) {
         Notice.destroy({
             where: { noticeID: id },
         })

--- a/controllers/notice.controller.js
+++ b/controllers/notice.controller.js
@@ -87,7 +87,10 @@ exports.create = (req, res) => {
 exports.findAll = (req, res) => {
     const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
 
-    if (req.header(reqHeaderAPIKeyField) == apiKey) {
+    if (
+        req.header(reqHeaderAPIKeyField) == apiKey ||
+        req.header(reqHeaderAPIKeyField) == adminKey
+    ) {
         Notice.findAll({
             order: [["noticeID", asc]],
             attributes: [

--- a/controllers/notice.controller.js
+++ b/controllers/notice.controller.js
@@ -96,6 +96,55 @@ exports.findAll = (req, res) => {
                 "createDate",
                 "isHidden",
             ],
+        })
+            .then((data) => {
+                res.status(200).send(data);
+                console.log(
+                    `[${moment().format(dateFormat)}] ${success} ${chalk.yellow(
+                        `${Notice.name} 테이블`
+                    )}의 모든 데이터를 성공적으로 조회했습니다. (IP: ${IP})`
+                );
+            })
+            .catch((err) => {
+                res.status(500).send({
+                    message: `${Notice.name} 테이블을 조회하는 중에 문제가 발생했습니다.`,
+                    detail: err.message,
+                });
+                console.log(
+                    `[${moment().format(
+                        dateFormat
+                    )}] ${unknownError} ${chalk.yellow(
+                        `${Notice.name} 테이블`
+                    )}을 조회하는 중에 문제가 발생했습니다. ${chalk.dim(
+                        `상세정보: ${err.message}`
+                    )} (IP: ${IP})`
+                );
+            });
+    } else {
+        res.status(403).send({ message: "Connection Fail" });
+        console.log(
+            `[${moment().format(
+                dateFormat
+            )}] ${badAccessError} Connection Fail at ${chalk.yellow(
+                "GET /notices"
+            )} (IP: ${IP})`
+        );
+    }
+};
+
+exports.findAllWithAdmin = (req, res) => {
+    const IP = req.header(reqHeaderIPField) || req.socket.remoteAddress;
+
+    if (req.header(reqHeaderAPIKeyField) == apiKey) {
+        Notice.findAll({
+            order: [["noticeID", asc]],
+            attributes: [
+                "noticeID",
+                "title",
+                "content",
+                "createDate",
+                "isHidden",
+            ],
             include: [
                 { model: Admin, as: "admin", attributes: ["adminID", "name"] },
             ],
@@ -129,7 +178,7 @@ exports.findAll = (req, res) => {
             `[${moment().format(
                 dateFormat
             )}] ${badAccessError} Connection Fail at ${chalk.yellow(
-                "GET /notices"
+                "GET /notices/admin"
             )} (IP: ${IP})`
         );
     }

--- a/routes/notice.routes.js
+++ b/routes/notice.routes.js
@@ -6,6 +6,7 @@ module.exports = (app) => {
     router.post("/", notices.create);
 
     router.get("/", notices.findAll);
+    router.get("/admin", notices.findAllWithAdmin);
     router.get("/:id", notices.findOne);
 
     router.put("/:id", notices.update);


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 앱에서 필요한 정보가 변경됨에 따라 전체 공지사항 조회 기능을 전체 공지사항 조회와 전체 공지사항 및 연관 관리자 조회 기능으로 분리하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- 전체 공지사항 조회 기능 변경 (`notices.findAll`)
- 전체 공지사항 및 연관 관리자 조회 기능 분리 (`notices.findAllWithAdmin`)

## ToDo 📆 (남은 작업)
- [ ] 없음

## ScreenShot 📷 (참고 사진)
- 없음

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 벌써 99번 이슈, 100번 PR이네요.
- 앱에서 필요한 정보가 변경되어 수정합니다. 코드가 크게 다르진 않으니 가볍게 확인해주셔도 됩니다.

## Reference 🔗
- 없음

## Close Issues 🔒 (닫을 Issue)
- Close #99.
